### PR TITLE
Fix: Ensure parameters are initialized with default values if undefined in `params.yml`

### DIFF
--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -108,6 +108,7 @@ class {{ node_class_name }}(Node):
             else:
                 self.get_logger().warn(f"Missing parameter '{name}', using default value: {default}")
                 param = default
+                self.set_parameters([rclpy.Parameter(name=name, value=param)])
 
         # add parameter to auto-reconfigurable parameters
         if add_to_auto_reconfigurable_params:


### PR DESCRIPTION
**Description:**  
This merge request resolves the issue where parameters declared in a Python ROS2 node were not being initialized when missing from `params.yml`. This caused the parameters to be inaccessible in parameter management tools like `rqt` and unavailable via `ros2 param get` commands.

---

**Issue Reference:**
Closes #4.

---

**Changes:**

- Modified the parameter declaration logic to ensure parameters are initialized with their default values even when not defined in `params.yml`.
- Used `set_parameters` after declaring the parameters to register them correctly.

---

**Steps to Reproduce:**  
The issue can be reproduced as follows:
1. Create a ROS2 node with the following parameter declaration:
   ```python
   self.param2 = 1
   self.param2 = self.declareAndLoadParameter(name="param2",
                                               param_type=rclpy.Parameter.Type.INTEGER,
                                               description="TODO",
                                               default=self.param2,
                                               from_value=0,
                                               to_value=9,
                                               step_value=1)
   ```
2. Launch the node without defining `param2` in `params.yml`.
3. Before the fix, no parameters would appear in `rqt` or via `ros2 param get`. After the fix, the declared parameter should be initialized and visible.

---

**Testing:**  
- Tested locally on ROS2 Humble with Ubuntu 22.04.
- Verified that:
  - Parameters not defined in `params.yml` are initialized with default values.
  - These parameters appear in `rqt`.
  - `ros2 param` commands (e.g., `ros2 param get`) correctly display the parameters.

---

**Impact:**  
This fix does not break existing functionality. Instead, it ensures that declared parameters are initialized properly, even if not defined in external configuration files.

---

**Screenshots/Logs:**  
(Optional: Include screenshots or logs demonstrating the fix in action. For example, a screenshot of `rqt` showing the previously missing parameter.)

---

**Code Snippet of the Fix:**

```python
# Ensure the parameter is explicitly registered if not provided in params.yml
            else:
                self.get_logger().warn(f"Missing parameter '{name}', using default value: {default}")
                param = default
                self.set_parameters([rclpy.Parameter(name=name, value=param)])
```
