### PR TITLE
Correct parameters typehint

### DIFF
--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.node import Node
+import rclpy.exceptions
 from rcl_interfaces.msg import (FloatingPointRange, IntegerRange, ParameterDescriptor, SetParametersResult)
 from std_msgs.msg import Int32
 from std_srvs.srv import SetBool
@@ -100,11 +101,11 @@ class Ros2PythonNode(Node):
         return param
 
     def parametersCallback(self,
-                           parameters: rclpy.Parameter) -> SetParametersResult:
+                           parameters: list[rclpy.Parameter]) -> SetParametersResult:
         """Handles reconfiguration when a parameter value is changed
 
         Args:
-            parameters (rclpy.Parameter): parameters
+            parameters (list[rclpy.Parameter]): parameters
 
         Returns:
             SetParametersResult: parameter change result

--- a/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
+++ b/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
@@ -2,6 +2,7 @@ from typing import Any, Optional, Union
 
 import rclpy
 from rclpy.node import Node
+import rclpy.exceptions
 from rcl_interfaces.msg import (FloatingPointRange, IntegerRange, ParameterDescriptor, SetParametersResult)
 from std_msgs.msg import Int32
 
@@ -96,11 +97,11 @@ class Ros2PythonNode(Node):
         return param
 
     def parametersCallback(self,
-                           parameters: rclpy.Parameter) -> SetParametersResult:
+                           parameters: list[rclpy.Parameter]) -> SetParametersResult:
         """Handles reconfiguration when a parameter value is changed
 
         Args:
-            parameters (rclpy.Parameter): parameters
+            parameters (list[rclpy.Parameter]): parameters
 
         Returns:
             SetParametersResult: parameter change result

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -9,6 +9,7 @@ from rclpy.action import ActionServer, CancelResponse, GoalResponse
 {% endif %}
 from rclpy.node import Node
 {% if has_params %}
+import rclpy.exceptions
 from rcl_interfaces.msg import (FloatingPointRange, IntegerRange, ParameterDescriptor, SetParametersResult)
 {% endif %}
 {% if has_subscriber or has_publisher %}

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -117,11 +117,11 @@ class {{ node_class_name }}(Node):
         return param
 
     def parametersCallback(self,
-                           parameters: rclpy.Parameter) -> SetParametersResult:
+                           parameters: list[rclpy.Parameter]) -> SetParametersResult:
         """Handles reconfiguration when a parameter value is changed
 
         Args:
-            parameters (rclpy.Parameter): parameters
+            parameters (list[rclpy.Parameter]): parameters
 
         Returns:
             SetParametersResult: parameter change result


### PR DESCRIPTION
Fixes https://github.com/ika-rwth-aachen/ros2-pkg-create/issues/11

I took the liberty to also explicitly import `rclpy.exceptions` since Pylance was reporting an error (although the import does resolve when the node is executed).