### PR TITLE
Python style

### DIFF
--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -14,26 +14,24 @@ class Ros2PythonNode(Node):
 
     def __init__(self):
         """Constructor"""
-
         super().__init__("ros2_python_node")
 
-        self.auto_reconfigurable_params = []
-        self.parameters_callback = None
         self.subscriber = None
+
         self.publisher = None
 
-        self.param = 1.0
-        self.param = self.declareAndLoadParameter(name="param",
-                                                  param_type=rclpy.Parameter.Type.DOUBLE,
-                                                  description="TODO",
-                                                  default=self.param,
-                                                  from_value=0.0,
-                                                  to_value=10.0,
-                                                  step_value=0.1)
+        self.auto_reconfigurable_params: list[str] = []
+        self.param = self.declare_and_load_parameter(name="param",
+                                                    param_type=rclpy.Parameter.Type.DOUBLE,
+                                                    description="TODO",
+                                                    default=1.0,
+                                                    from_value=0.0,
+                                                    to_value=10.0,
+                                                    step_value=0.1)
 
         self.setup()
 
-    def declareAndLoadParameter(self,
+    def declare_and_load_parameter(self,
         name: str,
         param_type: rclpy.Parameter.Type,
         description: str,
@@ -99,7 +97,7 @@ class Ros2PythonNode(Node):
 
         return param
 
-    def parametersCallback(self,
+    def parameters_callback(self,
                            parameters: rclpy.Parameter) -> SetParametersResult:
         """Handles reconfiguration when a parameter value is changed
 
@@ -124,13 +122,12 @@ class Ros2PythonNode(Node):
         """Sets up subscribers, publishers, etc. to configure the node"""
 
         # callback for dynamic parameter configuration
-        self.parameters_callback = self.add_on_set_parameters_callback(
-            self.parametersCallback)
+        self.add_on_set_parameters_callback(self.parameters_callback)
 
         # subscriber for handling incoming messages
         self.subscriber = self.create_subscription(Int32,
                                                    "~/input",
-                                                   self.topicCallback,
+                                                   self.topic_callback,
                                                    qos_profile=10)
         self.get_logger().info(f"Subscribed to '{self.subscriber.topic_name}'")
 
@@ -141,23 +138,23 @@ class Ros2PythonNode(Node):
         self.get_logger().info(f"Publishing to '{self.publisher.topic_name}'")
 
         # service server for handling service calls
-        self.service_server = self.create_service(SetBool, "~/service", self.serviceCallback)
+        self.service_server = self.create_service(SetBool, "~/service", self.service_callback)
 
         # action server for handling action goal requests
         self.action_server = ActionServer(
             self,
             Fibonacci,
             "~/action",
-            execute_callback=self.actionExecute,
-            goal_callback=self.actionHandleGoal,
-            cancel_callback=self.actionHandleCancel,
-            handle_accepted_callback=self.actionHandleAccepted
+            execute_callback=self.action_execute,
+            goal_callback=self.action_handle_goal,
+            cancel_callback=self.action_handle_cancel,
+            handle_accepted_callback=self.action_handle_accepted
         )
 
         # timer for repeatedly invoking a callback to publish messages
-        self.timer = self.create_timer(1.0, self.timerCallback)
+        self.timer = self.create_timer(1.0, self.timer_callback)
 
-    def topicCallback(self, msg: Int32):
+    def topic_callback(self, msg: Int32):
         """Processes messages received by a subscriber
 
         Args:
@@ -166,7 +163,7 @@ class Ros2PythonNode(Node):
 
         self.get_logger().info(f"Message received: '{msg.data}'")
 
-    def serviceCallback(self, request: SetBool.Request, response: SetBool.Response) -> SetBool.Response:
+    def service_callback(self, request: SetBool.Request, response: SetBool.Response) -> SetBool.Response:
         """Processes service requests
 
         Args:
@@ -182,7 +179,7 @@ class Ros2PythonNode(Node):
 
         return response
 
-    def actionHandleGoal(self, goal: Fibonacci.Goal) -> GoalResponse:
+    def action_handle_goal(self, goal: Fibonacci.Goal) -> GoalResponse:
         """Processes action goal requests
 
         Args:
@@ -196,7 +193,7 @@ class Ros2PythonNode(Node):
 
         return GoalResponse.ACCEPT
 
-    def actionHandleCancel(self, goal: Fibonacci.Goal) -> CancelResponse:
+    def action_handle_cancel(self, goal: Fibonacci.Goal) -> CancelResponse:
         """Processes action cancel requests
 
         Args:
@@ -210,7 +207,7 @@ class Ros2PythonNode(Node):
 
         return CancelResponse.ACCEPT
 
-    def actionHandleAccepted(self, goal: Fibonacci.Goal):
+    def action_handle_accepted(self, goal: Fibonacci.Goal):
         """Processes accepted action goal requests
 
         Args:
@@ -220,7 +217,7 @@ class Ros2PythonNode(Node):
         # execute action in a separate thread to avoid blocking
         goal.execute()
 
-    async def actionExecute(self, goal: Fibonacci.Goal) -> Fibonacci.Result:
+    async def action_execute(self, goal: Fibonacci.Goal) -> Fibonacci.Result:
         """Executes an action
 
         Args:
@@ -270,7 +267,7 @@ class Ros2PythonNode(Node):
 
         return result
 
-    def timerCallback(self):
+    def timer_callback(self):
         """Processes timer triggers
         """
 

--- a/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
+++ b/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
@@ -11,26 +11,24 @@ class Ros2PythonNode(Node):
 
     def __init__(self):
         """Constructor"""
-
         super().__init__("ros2_python_node")
 
-        self.auto_reconfigurable_params = []
-        self.parameters_callback = None
         self.subscriber = None
+
         self.publisher = None
 
-        self.param = 1.0
-        self.param = self.declareAndLoadParameter(name="param",
-                                                  param_type=rclpy.Parameter.Type.DOUBLE,
-                                                  description="TODO",
-                                                  default=self.param,
-                                                  from_value=0.0,
-                                                  to_value=10.0,
-                                                  step_value=0.1)
+        self.auto_reconfigurable_params: list[str] = []
+        self.param = self.declare_and_load_parameter(name="param",
+                                                    param_type=rclpy.Parameter.Type.DOUBLE,
+                                                    description="TODO",
+                                                    default=1.0,
+                                                    from_value=0.0,
+                                                    to_value=10.0,
+                                                    step_value=0.1)
 
         self.setup()
 
-    def declareAndLoadParameter(self,
+    def declare_and_load_parameter(self,
         name: str,
         param_type: rclpy.Parameter.Type,
         description: str,
@@ -96,7 +94,7 @@ class Ros2PythonNode(Node):
 
         return param
 
-    def parametersCallback(self,
+    def parameters_callback(self,
                            parameters: list[rclpy.Parameter]) -> SetParametersResult:
         """Handles reconfiguration when a parameter value is changed
 
@@ -121,13 +119,12 @@ class Ros2PythonNode(Node):
         """Sets up subscribers, publishers, etc. to configure the node"""
 
         # callback for dynamic parameter configuration
-        self.parameters_callback = self.add_on_set_parameters_callback(
-            self.parametersCallback)
+        self.add_on_set_parameters_callback(self.parameters_callback)
 
         # subscriber for handling incoming messages
         self.subscriber = self.create_subscription(Int32,
                                                    "~/input",
-                                                   self.topicCallback,
+                                                   self.topic_callback,
                                                    qos_profile=10)
         self.get_logger().info(f"Subscribed to '{self.subscriber.topic_name}'")
 
@@ -137,7 +134,7 @@ class Ros2PythonNode(Node):
                                                qos_profile=10)
         self.get_logger().info(f"Publishing to '{self.publisher.topic_name}'")
 
-    def topicCallback(self, msg: Int32):
+    def topic_callback(self, msg: Int32):
         """Processes messages received by a subscriber
 
         Args:

--- a/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
+++ b/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
@@ -10,26 +10,24 @@ class Ros2PythonNode(Node):
 
     def __init__(self):
         """Constructor"""
-
         super().__init__("ros2_python_node")
 
-        self.auto_reconfigurable_params = []
-        self.parameters_callback = None
         self.subscriber = None
+
         self.publisher = None
 
-        self.param = 1.0
-        self.param = self.declareAndLoadParameter(name="param",
-                                                  param_type=rclpy.Parameter.Type.DOUBLE,
-                                                  description="TODO",
-                                                  default=self.param,
-                                                  from_value=0.0,
-                                                  to_value=10.0,
-                                                  step_value=0.1)
+        self.auto_reconfigurable_params: list[str] = []
+        self.param = self.declare_and_load_parameter(name="param",
+                                                    param_type=rclpy.Parameter.Type.DOUBLE,
+                                                    description="TODO",
+                                                    default=1.0,
+                                                    from_value=0.0,
+                                                    to_value=10.0,
+                                                    step_value=0.1)
 
         self.setup()
 
-    def declareAndLoadParameter(self,
+    def declare_and_load_parameter(self,
         name: str,
         param_type: rclpy.Parameter.Type,
         description: str,
@@ -95,7 +93,7 @@ class Ros2PythonNode(Node):
 
         return param
 
-    def parametersCallback(self,
+    def parameters_callback(self,
                            parameters: rclpy.Parameter) -> SetParametersResult:
         """Handles reconfiguration when a parameter value is changed
 
@@ -120,13 +118,12 @@ class Ros2PythonNode(Node):
         """Sets up subscribers, publishers, etc. to configure the node"""
 
         # callback for dynamic parameter configuration
-        self.parameters_callback = self.add_on_set_parameters_callback(
-            self.parametersCallback)
+        self.add_on_set_parameters_callback(self.parameters_callback)
 
         # subscriber for handling incoming messages
         self.subscriber = self.create_subscription(Int32,
                                                    "~/input",
-                                                   self.topicCallback,
+                                                   self.topic_callback,
                                                    qos_profile=10)
         self.get_logger().info(f"Subscribed to '{self.subscriber.topic_name}'")
 
@@ -136,7 +133,7 @@ class Ros2PythonNode(Node):
                                                qos_profile=10)
         self.get_logger().info(f"Publishing to '{self.publisher.topic_name}'")
 
-    def topicCallback(self, msg: Int32):
+    def topic_callback(self, msg: Int32):
         """Processes messages received by a subscriber
 
         Args:

--- a/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
+++ b/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
@@ -10,24 +10,26 @@ class Ros2PythonNode(Node):
 
     def __init__(self):
         """Constructor"""
+
         super().__init__("ros2_python_node")
 
+        self.auto_reconfigurable_params = []
+        self.parameters_callback = None
         self.subscriber = None
-
         self.publisher = None
 
-        self.auto_reconfigurable_params: list[str] = []
-        self.param = self.declare_and_load_parameter(name="param",
-                                                    param_type=rclpy.Parameter.Type.DOUBLE,
-                                                    description="TODO",
-                                                    default=1.0,
-                                                    from_value=0.0,
-                                                    to_value=10.0,
-                                                    step_value=0.1)
+        self.param = 1.0
+        self.param = self.declareAndLoadParameter(name="param",
+                                                  param_type=rclpy.Parameter.Type.DOUBLE,
+                                                  description="TODO",
+                                                  default=self.param,
+                                                  from_value=0.0,
+                                                  to_value=10.0,
+                                                  step_value=0.1)
 
         self.setup()
 
-    def declare_and_load_parameter(self,
+    def declareAndLoadParameter(self,
         name: str,
         param_type: rclpy.Parameter.Type,
         description: str,
@@ -93,7 +95,7 @@ class Ros2PythonNode(Node):
 
         return param
 
-    def parameters_callback(self,
+    def parametersCallback(self,
                            parameters: rclpy.Parameter) -> SetParametersResult:
         """Handles reconfiguration when a parameter value is changed
 
@@ -118,12 +120,13 @@ class Ros2PythonNode(Node):
         """Sets up subscribers, publishers, etc. to configure the node"""
 
         # callback for dynamic parameter configuration
-        self.add_on_set_parameters_callback(self.parameters_callback)
+        self.parameters_callback = self.add_on_set_parameters_callback(
+            self.parametersCallback)
 
         # subscriber for handling incoming messages
         self.subscriber = self.create_subscription(Int32,
                                                    "~/input",
-                                                   self.topic_callback,
+                                                   self.topicCallback,
                                                    qos_profile=10)
         self.get_logger().info(f"Subscribed to '{self.subscriber.topic_name}'")
 
@@ -133,7 +136,7 @@ class Ros2PythonNode(Node):
                                                qos_profile=10)
         self.get_logger().info(f"Publishing to '{self.publisher.topic_name}'")
 
-    def topic_callback(self, msg: Int32):
+    def topicCallback(self, msg: Int32):
         """Processes messages received by a subscriber
 
         Args:

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -41,7 +41,7 @@ class {{ node_class_name }}(Node):
         self.param = self.declare_and_load_parameter(name="param",
                                                     param_type=rclpy.Parameter.Type.DOUBLE,
                                                     description="TODO",
-                                                    default=self.param,
+                                                    default=1.0,
                                                     from_value=0.0,
                                                     to_value=10.0,
                                                     step_value=0.1)

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -26,17 +26,18 @@ class {{ node_class_name }}(Node):
 
     def __init__(self):
         """Constructor"""
-
         super().__init__("{{ node_name }}")
+{% if has_subscriber %}
 
-{% if has_params %}
-        self.auto_reconfigurable_params = []
-        self.parameters_callback = None
-{% endif %}
         self.subscriber = None
+{% endif %}
+{% if has_publisher %}
+
         self.publisher = None
+{% endif %}
 {% if has_params %}
 
+        self.auto_reconfigurable_params: list[str] = []
         self.param = self.declare_and_load_parameter(name="param",
                                                     param_type=rclpy.Parameter.Type.DOUBLE,
                                                     description="TODO",
@@ -142,8 +143,7 @@ class {{ node_class_name }}(Node):
 {% if has_params %}
 
         # callback for dynamic parameter configuration
-        self.parameters_callback = self.add_on_set_parameters_callback(
-            self.parameters_callback)
+        self.add_on_set_parameters_callback(self.parameters_callback)
 {% endif %}
 {% if has_subscriber %}
 

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -37,20 +37,19 @@ class {{ node_class_name }}(Node):
         self.publisher = None
 {% if has_params %}
 
-        self.param = 1.0
-        self.param = self.declareAndLoadParameter(name="param",
-                                                  param_type=rclpy.Parameter.Type.DOUBLE,
-                                                  description="TODO",
-                                                  default=self.param,
-                                                  from_value=0.0,
-                                                  to_value=10.0,
-                                                  step_value=0.1)
+        self.param = self.declare_and_load_parameter(name="param",
+                                                    param_type=rclpy.Parameter.Type.DOUBLE,
+                                                    description="TODO",
+                                                    default=self.param,
+                                                    from_value=0.0,
+                                                    to_value=10.0,
+                                                    step_value=0.1)
 {% endif %}
 
         self.setup()
 {% if has_params %}
 
-    def declareAndLoadParameter(self,
+    def declare_and_load_parameter(self,
         name: str,
         param_type: rclpy.Parameter.Type,
         description: str,
@@ -116,7 +115,7 @@ class {{ node_class_name }}(Node):
 
         return param
 
-    def parametersCallback(self,
+    def parameters_callback(self,
                            parameters: rclpy.Parameter) -> SetParametersResult:
         """Handles reconfiguration when a parameter value is changed
 
@@ -144,14 +143,14 @@ class {{ node_class_name }}(Node):
 
         # callback for dynamic parameter configuration
         self.parameters_callback = self.add_on_set_parameters_callback(
-            self.parametersCallback)
+            self.parameters_callback)
 {% endif %}
 {% if has_subscriber %}
 
         # subscriber for handling incoming messages
         self.subscriber = self.create_subscription(Int32,
                                                    "~/input",
-                                                   self.topicCallback,
+                                                   self.topic_callback,
                                                    qos_profile=10)
         self.get_logger().info(f"Subscribed to '{self.subscriber.topic_name}'")
 {% endif %}
@@ -166,7 +165,7 @@ class {{ node_class_name }}(Node):
 {% if has_service_server %}
 
         # service server for handling service calls
-        self.service_server = self.create_service(SetBool, "~/service", self.serviceCallback)
+        self.service_server = self.create_service(SetBool, "~/service", self.service_callback)
 {% endif %}
 {% if has_action_server %}
 
@@ -175,24 +174,24 @@ class {{ node_class_name }}(Node):
             self,
             Fibonacci,
             "~/action",
-            execute_callback=self.actionExecute,
-            goal_callback=self.actionHandleGoal,
-            cancel_callback=self.actionHandleCancel,
-            handle_accepted_callback=self.actionHandleAccepted
+            execute_callback=self.action_execute,
+            goal_callback=self.action_handle_goal,
+            cancel_callback=self.action_handle_cancel,
+            handle_accepted_callback=self.action_handle_accepted
         )
 {% endif %}
 {% if has_timer %}
 
         # timer for repeatedly invoking a callback to publish messages
-        self.timer = self.create_timer(1.0, self.timerCallback)
+        self.timer = self.create_timer(1.0, self.timer_callback)
 {% endif %}
 {% if auto_shutdown %}
 
-        self.auto_shutdown_timer = self.create_timer(3.0, self.autoShutdownTimerCallback)
+        self.auto_shutdown_timer = self.create_timer(3.0, self.auto_shutdown_timer_callback)
 {% endif %}
 {% if has_subscriber %}
 
-    def topicCallback(self, msg: Int32):
+    def topic_callback(self, msg: Int32):
         """Processes messages received by a subscriber
 
         Args:
@@ -203,7 +202,7 @@ class {{ node_class_name }}(Node):
 {% endif %}
 {% if has_service_server %}
 
-    def serviceCallback(self, request: SetBool.Request, response: SetBool.Response) -> SetBool.Response:
+    def service_callback(self, request: SetBool.Request, response: SetBool.Response) -> SetBool.Response:
         """Processes service requests
 
         Args:
@@ -221,7 +220,7 @@ class {{ node_class_name }}(Node):
 {% endif %}
 {% if has_action_server %}
 
-    def actionHandleGoal(self, goal: Fibonacci.Goal) -> GoalResponse:
+    def action_handle_goal(self, goal: Fibonacci.Goal) -> GoalResponse:
         """Processes action goal requests
 
         Args:
@@ -235,7 +234,7 @@ class {{ node_class_name }}(Node):
 
         return GoalResponse.ACCEPT
 
-    def actionHandleCancel(self, goal: Fibonacci.Goal) -> CancelResponse:
+    def action_handle_cancel(self, goal: Fibonacci.Goal) -> CancelResponse:
         """Processes action cancel requests
 
         Args:
@@ -249,7 +248,7 @@ class {{ node_class_name }}(Node):
 
         return CancelResponse.ACCEPT
 
-    def actionHandleAccepted(self, goal: Fibonacci.Goal):
+    def action_handle_accepted(self, goal: Fibonacci.Goal):
         """Processes accepted action goal requests
 
         Args:
@@ -259,7 +258,7 @@ class {{ node_class_name }}(Node):
         # execute action in a separate thread to avoid blocking
         goal.execute()
 
-    async def actionExecute(self, goal: Fibonacci.Goal) -> Fibonacci.Result:
+    async def action_execute(self, goal: Fibonacci.Goal) -> Fibonacci.Result:
         """Executes an action
 
         Args:
@@ -311,7 +310,7 @@ class {{ node_class_name }}(Node):
 {% endif %}
 {% if has_timer %}
 
-    def timerCallback(self):
+    def timer_callback(self):
         """Processes timer triggers
         """
 
@@ -319,7 +318,7 @@ class {{ node_class_name }}(Node):
 {% endif %}
 {% if auto_shutdown %}
 
-    def autoShutdownTimerCallback(self):
+    def auto_shutdown_timer_callback(self):
         """Processes timer triggers to auto-shutdown the node
         """
 


### PR DESCRIPTION
This contributes to https://github.com/ika-rwth-aachen/ros2-pkg-create/issues/12

I replaced the camelCase method names with snake_case. I decided to _not_ make all lines adhere to the 100 character limit, since IMO that can easily be solved by the user by running any formatter.

This resulted in a name clash with variable `parameters_callback`, which was a return value of `self.add_on_set_parameters_callback(...)`. However, `self.add_on_set_parameters_callback(...)` returns `None` and we do not need to store that outcome so I removed the old `parameters_callback` attribute.

On top of that, I merged some parameter-related stuff into the same Jinja if-block so that everything fits nicely together.

Other Python templates in `ros2_python_pkg` such as the launch file did not need any changes.

Let me know if I missed anything!