### PR TITLE
Fix publishing for Components

### DIFF
--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -202,8 +202,8 @@ void {{ node_class_name }}::topicCallback(const std_msgs::msg::Int32::ConstShare
   {% if is_component %}
   std_msgs::msg::Int32::UniquePtr out_msg = std::make_unique<std_msgs::msg::Int32>();
   out_msg->data = msg->data;
-  publisher_->publish(std::move(out_msg));
   RCLCPP_INFO(this->get_logger(), "Message published: '%d'", out_msg->data);
+  publisher_->publish(std::move(out_msg));
   {% else %}
   std_msgs::msg::Int32 out_msg;
   out_msg.data = msg->data;


### PR DESCRIPTION
Hi, 
thanks for your great tool!
I was just testing it when I had issues when using the generated component.
It would run into a Segmentation Fault caused in line [206 of the cpp template](https://github.com/ika-rwth-aachen/ros2-pkg-create/blob/5f1b107ce0ed852a464adb9785f43db6bac85f11/templates/ros2_cpp_pkg/%7B%7B%20package_name%20%7D%7D/src/%7B%7B%20node_name%20%7D%7D.cpp.jinja#L206).

As the pointer to `out_msg->data` is no longer valid after `std::move()` the logging has to be done previous to the `move()` operation. Maybe not ideal, to log before the action, but it would be the quickest fix.

### How to reproduce:
- create a component with default settings
- load the component to a manager
- run a publisher of an integer

