### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/samples/ros2_cpp_all_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_all_pkg/CMakeLists.txt
@@ -29,14 +29,14 @@ target_include_directories(${TARGET_NAME} PUBLIC
 )
 target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
-ament_target_dependencies(${TARGET_NAME}
-  rclcpp
-  rclcpp_action
-  ros2_cpp_all_pkg_interfaces
-  rclcpp_components
-  rclcpp_lifecycle
-  std_msgs
-  std_srvs
+target_link_libraries(${TARGET_NAME} PUBLIC
+  ${rclcpp_TARGETS}
+  ${rclcpp_action_TARGETS}
+  ${ros2_cpp_all_pkg_interfaces_TARGETS}
+  ${rclcpp_components_TARGETS}
+  ${rclcpp_lifecycle_TARGETS}
+  ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
 )
 
 install(TARGETS ${TARGET_NAME}

--- a/samples/ros2_cpp_component_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_component_pkg/CMakeLists.txt
@@ -25,10 +25,10 @@ target_include_directories(${TARGET_NAME} PUBLIC
 )
 target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
-ament_target_dependencies(${TARGET_NAME}
-  rclcpp
-  rclcpp_components
-  std_msgs
+target_link_libraries(${TARGET_NAME} PUBLIC
+  ${rclcpp_TARGETS}
+  ${rclcpp_components_TARGETS}
+  ${std_msgs_TARGETS}
 )
 
 install(TARGETS ${TARGET_NAME}

--- a/samples/ros2_cpp_lifecycle_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_lifecycle_pkg/CMakeLists.txt
@@ -20,10 +20,10 @@ target_include_directories(${TARGET_NAME} PUBLIC
 )
 target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
-ament_target_dependencies(${TARGET_NAME}
-  rclcpp
-  rclcpp_lifecycle
-  std_msgs
+target_link_libraries(${TARGET_NAME} PUBLIC
+  ${rclcpp_TARGETS}
+  ${rclcpp_lifecycle_TARGETS}
+  ${std_msgs_TARGETS}
 )
 
 install(TARGETS ${TARGET_NAME}

--- a/samples/ros2_cpp_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_pkg/CMakeLists.txt
@@ -19,9 +19,9 @@ target_include_directories(${TARGET_NAME} PUBLIC
 )
 target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
-ament_target_dependencies(${TARGET_NAME}
-  rclcpp
-  std_msgs
+target_link_libraries(${TARGET_NAME} PUBLIC
+  ${rclcpp_TARGETS}
+  ${std_msgs_TARGETS}
 )
 
 install(TARGETS ${TARGET_NAME}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/CMakeLists.txt.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/CMakeLists.txt.jinja
@@ -45,21 +45,21 @@ target_include_directories(${TARGET_NAME} PUBLIC
 )
 target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
-ament_target_dependencies(${TARGET_NAME}
-  rclcpp
+target_link_libraries(${TARGET_NAME} PUBLIC
+  ${rclcpp_TARGETS}
 {% if has_action_server %}
-  rclcpp_action
-  {{ package_name }}_interfaces
+  ${rclcpp_action_TARGETS}
+  ${{ '{' }}{{ package_name }}_interfaces_TARGETS}
 {% endif %}
 {% if is_component %}
-  rclcpp_components
+  ${rclcpp_components_TARGETS}
 {% endif %}
 {% if is_lifecycle %}
-  rclcpp_lifecycle
+  ${rclcpp_lifecycle_TARGETS}
 {% endif %}
-  std_msgs
+  ${std_msgs_TARGETS}
 {% if has_service_server %}
-  std_srvs
+  ${std_srvs_TARGETS}
 {% endif %}
 )
 


### PR DESCRIPTION
## Summary
- revert accidental change to auto_shutdown questionnaire
- switch C++ templates and samples from `ament_target_dependencies` to `target_link_libraries`

## Testing
- `find ros2-pkg-create -path "*/templates/*" -prune -o -name '*.py' -print0 | xargs -0 -n1 python -m py_compile`
- `PYTHONPATH=ros2-pkg-create/src python -m ros2_pkg_create --version`


------
https://chatgpt.com/codex/tasks/task_e_68af73a74dec83219f84f6eab9105a08