### PR TITLE
Fix arg in xml launch file

### DIFF
--- a/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_launch_file %}launch{% endif %}/{% if launch_file_type == 'xml' %}{{ node_name }}_launch.xml{% endif %}.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_launch_file %}launch{% endif %}/{% if launch_file_type == 'xml' %}{{ node_name }}_launch.xml{% endif %}.jinja
@@ -6,7 +6,7 @@
 
   <node pkg="{{ package_name }}" exec="{{ node_name }}" namespace="$(var namespace)" name="$(var name)" output="screen">
 {% if has_params %}
-    <param from="$(arg params)" />
+    <param from="$(var params)" />
 {% endif %}
   </node>
 


### PR DESCRIPTION
`$(var param)` is used to reference parameters in ROS 2 XML Launch files: https://docs.ros.org/en/humble/Tutorials/Intermediate/Launch/Using-Substitutions.html#substitutions-example-launch-file

The currently generated launch file does not work but produces the error: `Unknown substitution: arg`