### PR TITLE
Add Diagnostics Updater

### DIFF
--- a/.github/workflows/check-samples.yml
+++ b/.github/workflows/check-samples.yml
@@ -24,6 +24,7 @@ jobs:
             has_service_server: false
             has_action_server: false
             has_timer: false
+            has_diagnostics: false
             has_docker_ros: true
           - package_name: ros2_cpp_component_pkg
             template: ros2_cpp_pkg
@@ -38,6 +39,7 @@ jobs:
             has_service_server: false
             has_action_server: false
             has_timer: false
+            has_diagnostics: false
             has_docker_ros: true
           - package_name: ros2_cpp_lifecycle_pkg
             template: ros2_cpp_pkg
@@ -52,6 +54,7 @@ jobs:
             has_service_server: false
             has_action_server: false
             has_timer: false
+            has_diagnostics: false
             has_docker_ros: true
           - package_name: ros2_cpp_multi_threaded_pkg
             template: ros2_cpp_pkg
@@ -66,6 +69,7 @@ jobs:
             has_service_server: false
             has_action_server: false
             has_timer: false
+            has_diagnostics: false
             has_docker_ros: true
           - package_name: ros2_cpp_all_pkg
             template: ros2_cpp_pkg
@@ -80,6 +84,7 @@ jobs:
             has_service_server: true
             has_action_server: true
             has_timer: true
+            has_diagnostics: true
             has_docker_ros: true
           - package_name: ros2_python_pkg
             template: ros2_python_pkg
@@ -93,6 +98,7 @@ jobs:
             has_service_server: false
             has_action_server: false
             has_timer: false
+            has_diagnostics: false
             has_docker_ros: true
           - package_name: ros2_python_all_pkg
             template: ros2_python_pkg
@@ -106,6 +112,7 @@ jobs:
             has_service_server: true
             has_action_server: true
             has_timer: true
+            has_diagnostics: true
             has_docker_ros: true
           - package_name: ros2_interfaces_pkg
             template: ros2_interfaces_pkg
@@ -140,6 +147,7 @@ jobs:
             -d has_service_server=${{ matrix.has_service_server }} \
             -d has_action_server=${{ matrix.has_action_server }} \
             -d has_timer=${{ matrix.has_timer }} \
+            -d has_diagnostics=${{ matrix.has_diagnostics }} \
             -d has_docker_ros=${{ matrix.has_docker_ros }} \
             . packages
       - name: Check for repository changes

--- a/.github/workflows/generate-and-test.yml
+++ b/.github/workflows/generate-and-test.yml
@@ -38,6 +38,11 @@ jobs:
             template: ros2_cpp_pkg
             has_timer: true
             auto_shutdown: true
+          - package_name: diagnostics_cpp_pkg
+            template: ros2_cpp_pkg
+            has_timer: true
+            has_diagnostics: true
+            auto_shutdown: true
           - package_name: no_params_cpp_pkg
             template: ros2_cpp_pkg
             has_params: false
@@ -53,6 +58,7 @@ jobs:
             has_service_server: true
             has_action_server: true
             has_timer: true
+            has_diagnostics: true
             auto_shutdown: true
           - package_name: default_python_pkg
             template: ros2_python_pkg
@@ -69,6 +75,10 @@ jobs:
             template: ros2_python_pkg
             has_timer: true
             auto_shutdown: true
+          - package_name: diagnostics_python_pkg
+            template: ros2_python_pkg
+            has_diagnostics: true
+            auto_shutdown: true
           - package_name: no_params_python_pkg
             template: ros2_python_pkg
             has_params: false
@@ -83,6 +93,7 @@ jobs:
             has_service_server: true
             has_action_server: true
             has_timer: true
+            has_diagnostics: true
             auto_shutdown: true
           - package_name: interfaces_pkg
             template: ros2_interfaces_pkg
@@ -112,6 +123,7 @@ jobs:
             $( [ "${{ matrix.has_service_server }}" = "true" ] && echo "-d has_service_server=true" ) \
             $( [ "${{ matrix.has_action_server }}" = "true" ] && echo "-d has_action_server=true" ) \
             $( [ "${{ matrix.has_timer }}" = "true" ] && echo "-d has_timer=true" ) \
+            $( [ "${{ matrix.has_diagnostics }}" = "true" ] && echo "-d has_diagnostics=true" ) \
             $( [ "${{ matrix.has_params }}" = "false" ] && echo "-d has_params=false" ) \
             $( [ "${{ matrix.has_launch_file }}" = "false" ] && echo "-d has_launch_file=false" ) \
             . packages
@@ -144,6 +156,8 @@ jobs:
             command: ros2 launch action_cpp_pkg action_cpp_pkg_launch.py
           - package: timer_cpp_pkg
             command: ros2 launch timer_cpp_pkg timer_cpp_pkg_launch.py
+          - package: diagnostics_cpp_pkg
+            command: ros2 launch diagnostics_cpp_pkg diagnostics_cpp_pkg_launch.py
           - package: no_params_cpp_pkg
             command: ros2 launch no_params_cpp_pkg no_params_cpp_pkg_launch.py
           - package: no_launch_file_cpp_pkg
@@ -158,6 +172,8 @@ jobs:
             command: ros2 launch action_python_pkg action_python_pkg_launch.py
           - package: timer_python_pkg
             command: ros2 launch timer_python_pkg timer_python_pkg_launch.py
+          - package: diagnostics_python_pkg
+            command: ros2 launch diagnostics_python_pkg diagnostics_python_pkg_launch.py
           - package: no_params_python_pkg
             command: ros2 launch no_params_python_pkg no_params_python_pkg_launch.py
           - package: no_launch_file_python_pkg

--- a/.github/workflows/generate-and-test.yml
+++ b/.github/workflows/generate-and-test.yml
@@ -194,6 +194,7 @@ jobs:
         shell: bash
         run: |
           source /opt/ros/$ROS_DISTRO/setup.bash
+          rosdep install -i --from-paths src -y
           colcon build --packages-up-to ${{ matrix.package }}
       - name: Run
         shell: bash

--- a/.github/workflows/generate-and-test.yml
+++ b/.github/workflows/generate-and-test.yml
@@ -195,7 +195,7 @@ jobs:
         run: |
           source /opt/ros/$ROS_DISTRO/setup.bash
           apt update && rosdep update
-          rosdep install -i --from-paths src -y
+          rosdep install -i --from-paths . -y
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/generate-and-test.yml
+++ b/.github/workflows/generate-and-test.yml
@@ -190,11 +190,16 @@ jobs:
         uses: actions/checkout@v4
       - name: Download artifacts
         uses: actions/download-artifact@v4
+      - name: Install dependencies
+        shell: bash
+        run: |
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          apt update && rosdep update
+          rosdep install -i --from-paths src -y
       - name: Build
         shell: bash
         run: |
           source /opt/ros/$ROS_DISTRO/setup.bash
-          rosdep install -i --from-paths src -y
           colcon build --packages-up-to ${{ matrix.package }}
       - name: Run
         shell: bash

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ eval "$(register-python-argcomplete ros2-pkg-create)"
 - Add a service server?
 - Add an action server?
 - Add a timer callback?
-- Add a diagnostics updater?
+- Add a diagnostics updater to publish diagnostics?
 - Add the docker-ros CI integration?
 </details>
 
@@ -107,7 +107,7 @@ eval "$(register-python-argcomplete ros2-pkg-create)"
 - Add a service server?
 - Add an action server?
 - Add a timer callback?
-- Add a diagnostics updater?
+- Add a diagnostics updater to publish diagnostics?
 - Add the docker-ros CI integration?
 </details>
 
@@ -194,7 +194,7 @@ options:
   --no-has-action-server
   --has-timer           Add a timer callback?
   --no-has-timer
-  --has-diagnostics     Add a diagnostics updater?
+  --has-diagnostics     Add a diagnostics updater to publish diagnostics?
   --no-has-diagnostics
   --auto-shutdown       Automatically shutdown the node after launch (useful in CI/CD)?
   --no-auto-shutdown

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ eval "$(register-python-argcomplete ros2-pkg-create)"
 - Add a service server?
 - Add an action server?
 - Add a timer callback?
+- Add a diagnostics publisher?
 - Add the docker-ros CI integration?
 </details>
 
@@ -106,6 +107,7 @@ eval "$(register-python-argcomplete ros2-pkg-create)"
 - Add a service server?
 - Add an action server?
 - Add a timer callback?
+- Add a diagnostics publisher?
 - Add the docker-ros CI integration?
 </details>
 

--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ eval "$(register-python-argcomplete ros2-pkg-create)"
 ## Usage
 
 ```
-usage: ros2-pkg-create [-h] [--defaults] [--use-local-templates] --template {ros2_interfaces_pkg,ros2_cpp_pkg,ros2_python_pkg} [--package-name PACKAGE_NAME] [--description DESCRIPTION] [--maintainer MAINTAINER] [--maintainer-email MAINTAINER_EMAIL] [--author AUTHOR]
-                       [--author-email AUTHOR_EMAIL] [--license {Apache-2.0,BSL-1.0,BSD-2.0,BSD-2-Clause,BSD-3-Clause,GPL-3.0-only,LGPL-2.1-only,LGPL-3.0-only,MIT,MIT-0}] [--node-name NODE_NAME] [--node-class-name NODE_CLASS_NAME] [--is-component] [--no-is-component] [--is-lifecycle]
-                       [--no-is-lifecycle] [--executor-type {SingleThreadedExecutor,MultiThreadedExecutor,StaticSingleThreadedExecutor}] [--has-launch-file] [--no-has-launch-file] [--launch-file-type {xml,py,yml}] [--has-params] [--no-has-params] [--has-subscriber] [--no-has-subscriber]
-                       [--has-publisher] [--no-has-publisher] [--has-service-server] [--no-has-service-server] [--has-action-server] [--no-has-action-server] [--has-timer] [--no-has-timer] [--auto-shutdown] [--no-auto-shutdown] [--interface-types {Message,Service,Action}]
-                       [--msg-name MSG_NAME] [--srv-name SRV_NAME] [--action-name ACTION_NAME] [--has-docker-ros] [--docker-ros-type {github,gitlab}] [--version]
+usage: ros2-pkg-create [-h] [--defaults] [--use-local-templates] --template {ros2_interfaces_pkg,ros2_cpp_pkg,ros2_python_pkg} [--package-name PACKAGE_NAME] [--description DESCRIPTION] [--maintainer MAINTAINER]
+                       [--maintainer-email MAINTAINER_EMAIL] [--author AUTHOR] [--author-email AUTHOR_EMAIL]
+                       [--license {Apache-2.0,BSL-1.0,BSD-2.0,BSD-2-Clause,BSD-3-Clause,GPL-3.0-only,LGPL-2.1-only,LGPL-3.0-only,MIT,MIT-0}] [--node-name NODE_NAME] [--node-class-name NODE_CLASS_NAME] [--is-component]
+                       [--no-is-component] [--is-lifecycle] [--no-is-lifecycle] [--executor-type {SingleThreadedExecutor,MultiThreadedExecutor,StaticSingleThreadedExecutor}] [--has-launch-file] [--no-has-launch-file]
+                       [--launch-file-type {xml,py,yml}] [--has-params] [--no-has-params] [--has-subscriber] [--no-has-subscriber] [--has-publisher] [--no-has-publisher] [--has-service-server] [--no-has-service-server]
+                       [--has-action-server] [--no-has-action-server] [--has-timer] [--no-has-timer] [--has-diagnostics] [--no-has-diagnostics] [--auto-shutdown] [--no-auto-shutdown]
+                       [--interface-types {Message,Service,Action}] [--msg-name MSG_NAME] [--srv-name SRV_NAME] [--action-name ACTION_NAME] [--has-docker-ros] [--docker-ros-type {github,gitlab}] [--version]
                        destination
 
 Creates a ROS 2 package from templates
@@ -192,6 +194,8 @@ options:
   --no-has-action-server
   --has-timer           Add a timer callback?
   --no-has-timer
+  --has-diagnostics     Add a diagnostics updater?
+  --no-has-diagnostics
   --auto-shutdown       Automatically shutdown the node after launch (useful in CI/CD)?
   --no-auto-shutdown
   --interface-types {Message,Service,Action}

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ eval "$(register-python-argcomplete ros2-pkg-create)"
 - Add a service server?
 - Add an action server?
 - Add a timer callback?
-- Add a diagnostics publisher?
+- Add a diagnostics updater?
 - Add the docker-ros CI integration?
 </details>
 
@@ -107,7 +107,7 @@ eval "$(register-python-argcomplete ros2-pkg-create)"
 - Add a service server?
 - Add an action server?
 - Add a timer callback?
-- Add a diagnostics publisher?
+- Add a diagnostics updater?
 - Add the docker-ros CI integration?
 </details>
 

--- a/copier.yml
+++ b/copier.yml
@@ -132,7 +132,7 @@ has_timer:
   default: false
 
 has_diagnostics:
-  help: Add diagnostics publisher?
+  help: Add diagnostics updater?
   when: "{{ template == 'ros2_cpp_pkg' or template == 'ros2_python_pkg' }}"
   type: bool
   default: false

--- a/copier.yml
+++ b/copier.yml
@@ -132,7 +132,7 @@ has_timer:
   default: false
 
 has_diagnostics:
-  help: Add diagnostics updater?
+  help: Add a diagnostics updater to publish diagnostics?
   when: "{{ template == 'ros2_cpp_pkg' or template == 'ros2_python_pkg' }}"
   type: bool
   default: false

--- a/copier.yml
+++ b/copier.yml
@@ -131,6 +131,12 @@ has_timer:
   type: bool
   default: false
 
+has_diagnostics:
+  help: Add diagnostics publisher?
+  when: "{{ template == 'ros2_cpp_pkg' or template == 'ros2_python_pkg' }}"
+  type: bool
+  default: false
+
 auto_shutdown:
   help: Automatically shutdown the node after launch (useful in CI/CD)?
   when: "{{ template == 'ros2_cpp_pkg' or template == 'ros2_python_pkg' }}"

--- a/ros2-pkg-create/src/ros2_pkg_create/__main__.py
+++ b/ros2-pkg-create/src/ros2_pkg_create/__main__.py
@@ -45,6 +45,8 @@ def parseArguments() -> argparse.Namespace:
     parser.add_argument("--no-has-action-server", dest="has-action-server", default=None, action="store_false")
     parser.add_argument("--has-timer", action="store_true", default=None, help="Add a timer callback?")
     parser.add_argument("--no-has-timer", dest="has-timer", default=None, action="store_false")
+    parser.add_argument("--has-diagnostics", action="store_true", default=None, help="Add a diagnostics updater?")
+    parser.add_argument("--no-has-diagnostics", dest="has-diagnostics", default=None, action="store_false")
     parser.add_argument("--auto-shutdown", action="store_true", default=None, help="Automatically shutdown the node after launch (useful in CI/CD)?")
     parser.add_argument("--no-auto-shutdown", dest="auto-shutdown", default=None, action="store_false")
     parser.add_argument("--interface-types", type=str, default=None, choices=["Message", "Service", "Action"], help="Interfaces types")

--- a/ros2-pkg-create/src/ros2_pkg_create/__main__.py
+++ b/ros2-pkg-create/src/ros2_pkg_create/__main__.py
@@ -45,7 +45,7 @@ def parseArguments() -> argparse.Namespace:
     parser.add_argument("--no-has-action-server", dest="has-action-server", default=None, action="store_false")
     parser.add_argument("--has-timer", action="store_true", default=None, help="Add a timer callback?")
     parser.add_argument("--no-has-timer", dest="has-timer", default=None, action="store_false")
-    parser.add_argument("--has-diagnostics", action="store_true", default=None, help="Add a diagnostics updater?")
+    parser.add_argument("--has-diagnostics", action="store_true", default=None, help="Add a diagnostics updater to publish diagnostics?")
     parser.add_argument("--no-has-diagnostics", dest="has-diagnostics", default=None, action="store_false")
     parser.add_argument("--auto-shutdown", action="store_true", default=None, help="Automatically shutdown the node after launch (useful in CI/CD)?")
     parser.add_argument("--no-auto-shutdown", dest="auto-shutdown", default=None, action="store_false")

--- a/samples/generate_samples.sh
+++ b/samples/generate_samples.sh
@@ -17,6 +17,7 @@ copier copy --trust --defaults --overwrite --vcs-ref=HEAD \
             -d has_service_server=false \
             -d has_action_server=false \
             -d has_timer=false \
+            -d has_diagnostics=false \
             -d has_docker_ros=true \
             $template_dir $script_dir
 
@@ -34,6 +35,7 @@ copier copy --trust --defaults --overwrite --vcs-ref=HEAD \
             -d has_service_server=false \
             -d has_action_server=false \
             -d has_timer=false \
+            -d has_diagnostics=false \
             -d has_docker_ros=true \
             $template_dir $script_dir
 
@@ -51,6 +53,7 @@ copier copy --trust --defaults --overwrite --vcs-ref=HEAD \
             -d has_service_server=false \
             -d has_action_server=false \
             -d has_timer=false \
+            -d has_diagnostics=false \
             -d has_docker_ros=true \
             $template_dir $script_dir
 
@@ -68,6 +71,7 @@ copier copy --trust --defaults --overwrite --vcs-ref=HEAD \
             -d has_service_server=false \
             -d has_action_server=false \
             -d has_timer=false \
+            -d has_diagnostics=false \
             -d has_docker_ros=true \
             $template_dir $script_dir
 
@@ -85,6 +89,7 @@ copier copy --trust --defaults --overwrite --vcs-ref=HEAD \
             -d has_service_server=true \
             -d has_action_server=true \
             -d has_timer=true \
+            -d has_diagnostics=true \
             -d has_docker_ros=true \
             $template_dir $script_dir
 
@@ -99,6 +104,7 @@ copier copy --trust --defaults --overwrite --vcs-ref=HEAD \
             -d has_service_server=false \
             -d has_action_server=false \
             -d has_timer=false \
+            -d has_diagnostics=false \
             -d has_docker_ros=true \
             $template_dir $script_dir
 
@@ -113,6 +119,7 @@ copier copy --trust --defaults --overwrite --vcs-ref=HEAD \
             -d has_service_server=true \
             -d has_action_server=true \
             -d has_timer=true \
+            -d has_diagnostics=true \
             -d has_docker_ros=true \
             $template_dir $script_dir
 

--- a/samples/ros2_cpp_all_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_all_pkg/CMakeLists.txt
@@ -7,12 +7,12 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(diagnostic_updater REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(ros2_cpp_all_pkg_interfaces REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 
 set(TARGET_NAME ros2_cpp_node_component)
@@ -34,11 +34,11 @@ target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 target_link_libraries(${TARGET_NAME} PUBLIC
   rclcpp::rclcpp
   ${diagnostic_updater_TARGETS}
+  ${geometry_msgs_TARGETS}
   ${rclcpp_action_TARGETS}
   ${ros2_cpp_all_pkg_interfaces_TARGETS}
   ${rclcpp_components_TARGETS}
   ${rclcpp_lifecycle_TARGETS}
-  ${std_msgs_TARGETS}
   ${std_srvs_TARGETS}
 )
 

--- a/samples/ros2_cpp_all_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_all_pkg/CMakeLists.txt
@@ -6,12 +6,12 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(ros2_cpp_all_pkg_interfaces REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
-find_package(diagnostic_updater REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 
@@ -33,11 +33,11 @@ target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
 target_link_libraries(${TARGET_NAME} PUBLIC
   rclcpp::rclcpp
+  ${diagnostic_updater_TARGETS}
   ${rclcpp_action_TARGETS}
   ${ros2_cpp_all_pkg_interfaces_TARGETS}
   ${rclcpp_components_TARGETS}
   ${rclcpp_lifecycle_TARGETS}
-  ${diagnostic_updater_TARGETS}
   ${std_msgs_TARGETS}
   ${std_srvs_TARGETS}
 )

--- a/samples/ros2_cpp_all_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_all_pkg/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rclcpp_action REQUIRED)
 find_package(ros2_cpp_all_pkg_interfaces REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 
@@ -36,6 +37,7 @@ target_link_libraries(${TARGET_NAME} PUBLIC
   ${ros2_cpp_all_pkg_interfaces_TARGETS}
   ${rclcpp_components_TARGETS}
   ${rclcpp_lifecycle_TARGETS}
+  ${diagnostic_updater_TARGETS}
   ${std_msgs_TARGETS}
   ${std_srvs_TARGETS}
 )

--- a/samples/ros2_cpp_all_pkg/config/params.yml
+++ b/samples/ros2_cpp_all_pkg/config/params.yml
@@ -1,6 +1,6 @@
 /**/*:
   ros__parameters:
     diagnostic_updater:
-      period: 0.1
+      period: 1.0
       use_fqn: false
     param: 1.0

--- a/samples/ros2_cpp_all_pkg/config/params.yml
+++ b/samples/ros2_cpp_all_pkg/config/params.yml
@@ -4,13 +4,13 @@
     diagnostic_updater:
       period: 1.0
       use_fqn: false
-    topic_diagnostic:
-      min_frequency: 0.5
-      max_frequency: 1.0
-      min_acceptable_timestamp_delta: -0.1
-      max_acceptable_timestamp_delta: 0.1
-    diagnosed_publisher:
-      min_frequency: 0.5
-      max_frequency: 1.0
-      min_acceptable_timestamp_delta: -0.1
-      max_acceptable_timestamp_delta: 0.1
+      topic_diagnostic:
+        min_frequency: 0.5
+        max_frequency: 1.0
+        min_acceptable_timestamp_delta: -0.1
+        max_acceptable_timestamp_delta: 0.1
+      diagnosed_publisher:
+        min_frequency: 0.5
+        max_frequency: 1.0
+        min_acceptable_timestamp_delta: -0.1
+        max_acceptable_timestamp_delta: 0.1

--- a/samples/ros2_cpp_all_pkg/config/params.yml
+++ b/samples/ros2_cpp_all_pkg/config/params.yml
@@ -1,3 +1,4 @@
 /**/*:
   ros__parameters:
+    diagnostic_updater.period: 0.1
     param: 1.0

--- a/samples/ros2_cpp_all_pkg/config/params.yml
+++ b/samples/ros2_cpp_all_pkg/config/params.yml
@@ -1,6 +1,16 @@
 /**/*:
   ros__parameters:
+    param: 1.0
     diagnostic_updater:
       period: 1.0
       use_fqn: false
-    param: 1.0
+    topic_diagnostic:
+      min_frequency: 0.5
+      max_frequency: 1.0
+      min_acceptable_timestamp_delta: -0.1
+      max_acceptable_timestamp_delta: 0.1
+    diagnosed_publisher:
+      min_frequency: 0.5
+      max_frequency: 1.0
+      min_acceptable_timestamp_delta: -0.1
+      max_acceptable_timestamp_delta: 0.1

--- a/samples/ros2_cpp_all_pkg/config/params.yml
+++ b/samples/ros2_cpp_all_pkg/config/params.yml
@@ -1,4 +1,6 @@
 /**/*:
   ros__parameters:
-    diagnostic_updater.period: 0.1
+    diagnostic_updater:
+      period: 0.1
+      use_fqn: false
     param: 1.0

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -205,7 +205,7 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
   void health(diagnostic_updater::DiagnosticStatusWrapper &stat);
 
   /**
-   * @brief Sets the health information published by diagnostic updater
+   * @brief Sets the health information and triggers publishing by diagnostic updater
    */
   void setHealth(const unsigned char status, const std::string& msg, const std::map<std::string, std::string>& key_value_pairs = {});
 

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -221,16 +221,27 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
   double param_ = 1.0;
 
   /**
-   * @brief Diagnostic updater publishes to "/diagnostics" with period set in parameter "~diagnostic_updater.period"
+   * @brief Diagnostic updater
    */
   diagnostic_updater::Updater diagnostic_updater_{this};
-  unsigned char system_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+  
+   /**
+   * @brief Diagnostic status indicating node health
+   */
+  unsigned char health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+  /**
+   * @brief Topic diagnostic to diagnose a subscribed topic
+   */
   std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> subscriber_diagnostic_;
+  
+  /**
+   * @brief Parameters for configuring subscriber diagnostic monitoring
+   */
   struct {
-    double freq_min = 0.5;
-    double freq_max = 5.0;
-    double freq_tolerance = 0.1;
-    int freq_window_size = 5;
+    double min_frequency = 0.5;           ///< Minimum expected message frequency (Hz)
+    double max_frequency = 5.0;           ///< Maximum expected message frequency (Hz)
+    double frequency_tolerance = 0.1;     ///< Tolerance for frequency deviation. Acceptable values are from 'min_frequency*(1-frequency_tolerance)' to 'max_frequency*(1+frequency_tolerance)'.
+    int frequency_window_size = 5;        ///< Number of diagnostic calls (depending on 'diagnostic_updater.period' parameter) to consider in the frequency calculation. It should be large enough to get a reliable estimate of the frequency depending on the expected message rate in relation to the diagnostic updater period.
   } subscriber_diagnostic_params_;
 };
 

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -230,19 +230,34 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    */
   unsigned char health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
   /**
-   * @brief Topic diagnostic to diagnose a subscribed topic
+   * @brief Topic diagnostic to auto-diagnose a subscribed topic
    */
-  std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> subscriber_diagnostic_;
+  std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> topic_diagnostic_;
   
   /**
-   * @brief Parameters for configuring subscriber diagnostic monitoring
+   * @brief Minimum acceptable frequency of auto-diagnosed topic subscription
    */
-  struct {
-    double min_frequency = 0.5;           ///< Minimum expected message frequency (Hz)
-    double max_frequency = 5.0;           ///< Maximum expected message frequency (Hz)
-    double frequency_tolerance = 0.1;     ///< Tolerance for frequency deviation. Acceptable values are from 'min_frequency*(1-frequency_tolerance)' to 'max_frequency*(1+frequency_tolerance)'.
-    int frequency_window_size = 5;        ///< Number of diagnostic calls (depending on 'diagnostic_updater.period' parameter) to consider in the frequency calculation. It should be large enough to get a reliable estimate of the frequency depending on the expected message rate in relation to the diagnostic updater period.
-  } subscriber_diagnostic_params_;
+  double topic_diagnostic_min_frequency_ = 1.0;
+  
+  /**
+   * @brief Maximum acceptable frequency of auto-diagnosed topic subscription
+   */
+  double topic_diagnostic_max_frequency_ = 1.0;
+  
+  /**
+   * @brief Tolerance for frequency deviation.
+   * Acceptable frequencies are from `min_frequency * (1 - frequency_tolerance)`
+   * to `max_frequency * (1 + frequency_tolerance)`.
+   */
+  const double topic_diagnostic_frequency_tolerance_ = 0.1;
+  
+  /**
+   * @brief Number of diagnostic calls to consider in the frequency calculation.
+   * It should be large enough to get a reliable estimate of the frequency depending
+   * on the expected message rate in relation to the diagnostic updater period.
+   */
+  const int topic_diagnostic_frequency_window_size_ = 5;
+  
 };
 
 

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -219,6 +219,7 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    * @brief Diagnostic updater publishes to "/diagnostics" with period set in parameter "~diagnostic_updater.period"
    */
   diagnostic_updater::Updater diagnostic_updater_{this};
+  unsigned char system_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
   std::vector<std::shared_ptr<diagnostic_updater::DiagnosticTask>> diagnostic_tasks_;
   std::unique_ptr<diagnostic_updater::TopicDiagnostic> topic_diagnostic_;
   double min_freq_ = 0.5;

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -204,6 +204,11 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    */
   void health(diagnostic_updater::DiagnosticStatusWrapper &stat);
 
+  /**
+   * @brief Sets the health information published by diagnostic updater
+   */
+  void setHealth(const unsigned char status, const std::string& msg, const std::map<std::string, std::string>& key_value_pairs = {});
+
  private:
 
   /**
@@ -254,7 +259,11 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    /**
    * @brief Diagnostic status indicating node health
    */
-  unsigned char health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+  struct DiagnosticStatus {
+    unsigned char status = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+    std::string message = "";
+    std::map<std::string, std::string> key_value_pairs = {};
+  } health_;
 
   /**
    * @brief Topic diagnostic to auto-diagnose a subscribed topic

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -231,7 +231,7 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
   /**
    * @brief Function called by diagnostic updater to populate diagnostics status
    */
-  void diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);
+  void health(diagnostic_updater::DiagnosticStatusWrapper &stat);
 };
 
 

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -26,6 +26,32 @@ template <typename C> inline constexpr bool is_vector_v = is_vector<C>::value;
 
 
 /**
+ * @brief Configuration parameters for topic diagnostics
+ */
+struct TopicDiagnosticConfig {
+  /**
+   * @brief Minimum acceptable frequency
+   */
+  double min_frequency;
+  
+  /**
+   * @brief Maximum acceptable frequency
+   */
+  double max_frequency;
+  
+  /**
+   * @brief Minimum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  double min_acceptable_timestamp_delta;
+
+  /**
+   * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  double max_acceptable_timestamp_delta;
+};
+
+
+/**
  * @brief Ros2CppNode class
  */
 class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
@@ -234,40 +260,11 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    * @brief Topic diagnostic to auto-diagnose a subscribed topic
    */
   std::unique_ptr<diagnostic_updater::TopicDiagnostic> topic_diagnostic_;
-  
-  /**
-   * @brief Minimum acceptable frequency of auto-diagnosed topic subscription
-   */
-  double topic_diagnostic_min_frequency_ = 1.0;
-  
-  /**
-   * @brief Maximum acceptable frequency of auto-diagnosed topic subscription
-   */
-  double topic_diagnostic_max_frequency_ = 1.0;
-  
-  /**
-   * @brief Tolerance for frequency deviation.
-   * Acceptable frequencies are from `min_frequency * (1 - frequency_tolerance)`
-   * to `max_frequency * (1 + frequency_tolerance)`.
-   */
-  const double topic_diagnostic_frequency_tolerance_ = 0.1;
-  
-  /**
-   * @brief Number of diagnostic calls to consider in the frequency calculation.
-   * It should be large enough to get a reliable estimate of the frequency depending
-   * on the expected message rate in relation to the diagnostic updater period.
-   */
-  const int topic_diagnostic_frequency_window_size_ = 5;
 
   /**
-   * @brief Minimum acceptable difference between message timestamp and receipt time (in seconds)
+   * @brief Configuration for auto-diagnosed topic subscription
    */
-  const double topic_diagnostic_min_acceptable_stamp_delta_ = -1.0;
-
-  /**
-   * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
-   */
-  const double topic_diagnostic_max_acceptable_stamp_delta_ = 5.0;  
+  TopicDiagnosticConfig topic_diagnostic_config_;
 
   /**
    * @brief Diagnosed publisher
@@ -275,38 +272,9 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
   std::unique_ptr<diagnostic_updater::DiagnosedPublisher<geometry_msgs::msg::PointStamped>> diagnosed_publisher_;
 
   /**
-   * @brief Minimum acceptable frequency of auto-diagnosed publisher
+   * @brief Configuration for auto-diagnosed publisher
    */
-  double diagnosed_publisher_min_frequency_ = 1.0;
-  
-  /**
-   * @brief Maximum acceptable frequency of auto-diagnosed publisher
-   */
-  double diagnosed_publisher_max_frequency_ = 1.0;
-  
-  /**
-   * @brief Tolerance for frequency deviation.
-   * Acceptable frequencies are from `min_frequency * (1 - frequency_tolerance)`
-   * to `max_frequency * (1 + frequency_tolerance)`.
-   */
-  const double diagnosed_publisher_frequency_tolerance_ = 0.1;
-  
-  /**
-   * @brief Number of diagnostic calls to consider in the frequency calculation.
-   * It should be large enough to get a reliable estimate of the frequency depending
-   * on the expected message rate in relation to the diagnostic updater period.
-   */
-  const int diagnosed_publisher_frequency_window_size_ = 5;
-
-  /**
-   * @brief Minimum acceptable difference between message timestamp and receipt time (in seconds)
-   */
-  const double diagnosed_publisher_min_acceptable_stamp_delta_ = -1.0;
-
-  /**
-   * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
-   */
-  const double diagnosed_publisher_max_acceptable_stamp_delta_ = 5.0;  
+  TopicDiagnosticConfig diagnosed_publisher_config_;  
 };
 
 

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -220,12 +220,13 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    */
   diagnostic_updater::Updater diagnostic_updater_{this};
   unsigned char system_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
-  std::vector<std::shared_ptr<diagnostic_updater::DiagnosticTask>> diagnostic_tasks_;
-  std::unique_ptr<diagnostic_updater::TopicDiagnostic> topic_diagnostic_;
-  double min_freq_ = 0.5;
-  double max_freq_ = 5.0;
-  double min_delta_stamp_ = -0.1;
-  double max_delta_stamp_ = 0.1;
+  std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> subscriber_diagnostic_;
+  struct {
+    double freq_min = 0.5;
+    double freq_max = 5.0;
+    double freq_tolerance = 0.1;
+    int freq_window_size = 5;
+  } subscriber_diagnostic_params_;
 
   /**
    * @brief Function called by diagnostic updater to populate diagnostics status

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -173,6 +173,11 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    */
   void timerCallback();
 
+  /**
+   * @brief Function called by diagnostic updater to populate diagnostics status
+   */
+  void health(diagnostic_updater::DiagnosticStatusWrapper &stat);
+
  private:
 
   /**
@@ -227,11 +232,6 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
     double freq_tolerance = 0.1;
     int freq_window_size = 5;
   } subscriber_diagnostic_params_;
-
-  /**
-   * @brief Function called by diagnostic updater to populate diagnostics status
-   */
-  void health(diagnostic_updater::DiagnosticStatusWrapper &stat);
 };
 
 

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <diagnostic_updater/publisher.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 #include <lifecycle_msgs/msg/transition.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -12,8 +14,6 @@
 #include <rclcpp_lifecycle/lifecycle_publisher.hpp>
 #include <std_msgs/msg/int32.hpp>
 #include <std_srvs/srv/set_bool.hpp>
-#include <diagnostic_updater/diagnostic_updater.hpp>
-#include <diagnostic_updater/publisher.hpp>
 
 #include <ros2_cpp_all_pkg_interfaces/action/fibonacci.hpp>
 

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -229,6 +229,7 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    * @brief Diagnostic status indicating node health
    */
   unsigned char health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+
   /**
    * @brief Topic diagnostic to auto-diagnose a subscribed topic
    */
@@ -267,6 +268,45 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
    */
   const double topic_diagnostic_max_acceptable_stamp_delta_ = 5.0;  
+
+  /**
+   * @brief Diagnosed publisher
+   */
+  std::unique_ptr<diagnostic_updater::DiagnosedPublisher<geometry_msgs::msg::PointStamped>> diagnosed_publisher_;
+
+  /**
+   * @brief Minimum acceptable frequency of auto-diagnosed publisher
+   */
+  double diagnosed_publisher_min_frequency_ = 1.0;
+  
+  /**
+   * @brief Maximum acceptable frequency of auto-diagnosed publisher
+   */
+  double diagnosed_publisher_max_frequency_ = 1.0;
+  
+  /**
+   * @brief Tolerance for frequency deviation.
+   * Acceptable frequencies are from `min_frequency * (1 - frequency_tolerance)`
+   * to `max_frequency * (1 + frequency_tolerance)`.
+   */
+  const double diagnosed_publisher_frequency_tolerance_ = 0.1;
+  
+  /**
+   * @brief Number of diagnostic calls to consider in the frequency calculation.
+   * It should be large enough to get a reliable estimate of the frequency depending
+   * on the expected message rate in relation to the diagnostic updater period.
+   */
+  const int diagnosed_publisher_frequency_window_size_ = 5;
+
+  /**
+   * @brief Minimum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  const double diagnosed_publisher_min_acceptable_stamp_delta_ = -1.0;
+
+  /**
+   * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  const double diagnosed_publisher_max_acceptable_stamp_delta_ = 5.0;  
 };
 
 

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -6,13 +6,13 @@
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <diagnostic_updater/publisher.hpp>
+#include <geometry_msgs/msg/point_stamped.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 #include <lifecycle_msgs/msg/transition.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <rclcpp_lifecycle/lifecycle_publisher.hpp>
-#include <std_msgs/msg/int32.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 
 #include <ros2_cpp_all_pkg_interfaces/action/fibonacci.hpp>
@@ -127,7 +127,7 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    *
    * @param msg message
    */
-  void topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg);
+  void topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg);
 
   /**
    * @brief Processes service requests
@@ -193,12 +193,12 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
   /**
    * @brief Subscriber
    */
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr subscriber_;
+  rclcpp::Subscription<geometry_msgs::msg::PointStamped>::SharedPtr subscriber_;
 
   /**
    * @brief Publisher
    */
-  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Int32>::SharedPtr publisher_;
+  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PointStamped>::SharedPtr publisher_;
 
   /**
    * @brief Service server
@@ -232,7 +232,7 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
   /**
    * @brief Topic diagnostic to auto-diagnose a subscribed topic
    */
-  std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> topic_diagnostic_;
+  std::unique_ptr<diagnostic_updater::TopicDiagnostic> topic_diagnostic_;
   
   /**
    * @brief Minimum acceptable frequency of auto-diagnosed topic subscription
@@ -257,7 +257,16 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    * on the expected message rate in relation to the diagnostic updater period.
    */
   const int topic_diagnostic_frequency_window_size_ = 5;
-  
+
+  /**
+   * @brief Minimum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  const double topic_diagnostic_min_acceptable_stamp_delta_ = -1.0;
+
+  /**
+   * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  const double topic_diagnostic_max_acceptable_stamp_delta_ = 5.0;  
 };
 
 

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -12,6 +12,7 @@
 #include <rclcpp_lifecycle/lifecycle_publisher.hpp>
 #include <std_msgs/msg/int32.hpp>
 #include <std_srvs/srv/set_bool.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
 
 #include <ros2_cpp_all_pkg_interfaces/action/fibonacci.hpp>
 
@@ -212,6 +213,16 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    * @brief Dummy parameter (parameter)
    */
   double param_ = 1.0;
+
+  /**
+   * @brief Diagnostic updater publishes to "/diagnostics" with period set in parameter "~diagnostic_updater.period"
+   */
+  diagnostic_updater::Updater diagnostic_updater_{this};
+
+  /**
+   * @brief Function called by diagnostic updater to populate diagnostics status
+   */
+  void diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);
 };
 
 

--- a/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_all_pkg/include/ros2_cpp_all_pkg/ros2_cpp_node.hpp
@@ -13,6 +13,7 @@
 #include <std_msgs/msg/int32.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
+#include <diagnostic_updater/publisher.hpp>
 
 #include <ros2_cpp_all_pkg_interfaces/action/fibonacci.hpp>
 
@@ -218,6 +219,12 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    * @brief Diagnostic updater publishes to "/diagnostics" with period set in parameter "~diagnostic_updater.period"
    */
   diagnostic_updater::Updater diagnostic_updater_{this};
+  std::vector<std::shared_ptr<diagnostic_updater::DiagnosticTask>> diagnostic_tasks_;
+  std::unique_ptr<diagnostic_updater::TopicDiagnostic> topic_diagnostic_;
+  double min_freq_ = 0.5;
+  double max_freq_ = 5.0;
+  double min_delta_stamp_ = -0.1;
+  double max_delta_stamp_ = 0.1;
 
   /**
    * @brief Function called by diagnostic updater to populate diagnostics status

--- a/samples/ros2_cpp_all_pkg/package.xml
+++ b/samples/ros2_cpp_all_pkg/package.xml
@@ -14,11 +14,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>diagnostic_updater</depend>
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>
-  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>ros2_cpp_all_pkg_interfaces</depend>
 

--- a/samples/ros2_cpp_all_pkg/package.xml
+++ b/samples/ros2_cpp_all_pkg/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -275,22 +275,33 @@ void Ros2CppNode::timerCallback() {
 
 void Ros2CppNode::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
-  // TODO: fill diagnostic status message appropriately based on current system state
-  if(health_ == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.");
-    health_ = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-  } else if(health_ == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.");
-    health_ = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  } else if(health_ == diagnostic_msgs::msg::DiagnosticStatus::OK) {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is able to assess its own performance level and is reaching its desired performance level.");
-    health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+  // TODO: Remove this demonstration of health status and implement real health checks using `setHealth()`
+  if(health_.status == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+    setHealth(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.", { {"uptime", std::to_string(this->get_clock()->now().seconds())} });
+    health_.status = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+  } else if(health_.status == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
+    setHealth(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.");
+    health_.status = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  } else if(health_.status == diagnostic_msgs::msg::DiagnosticStatus::OK) {
+    setHealth(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is able to assess its own performance level and is reaching its desired performance level.");
+    health_.status = diagnostic_msgs::msg::DiagnosticStatus::STALE;
   } else {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "Node performance level cannot be assessed");
-    health_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    setHealth(diagnostic_msgs::msg::DiagnosticStatus::STALE, "Node performance level cannot be assessed");
+    health_.status = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
   }
-  // optional: add custom key-value pairs to diagnostics status
-  stat.add("Dummy Status Key", "Dummy Status Value");
+  // end of demonstration
+
+  stat.summary(health_.status, health_.message);
+  for (const auto& [key, value] : health_.key_value_pairs) {
+    stat.add(key, value);
+  }
+}
+
+
+void Ros2CppNode::setHealth(const unsigned char status, const std::string& msg, const std::map<std::string, std::string>& key_value_pairs) {
+  health_.status = status;
+  health_.message = msg;
+  health_.key_value_pairs = key_value_pairs;
 }
 
 

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -157,6 +157,7 @@ void Ros2CppNode::setup() {
 
 void Ros2CppNode::topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg) {
 
+  subscriber_diagnostic_->tick();
   RCLCPP_INFO(this->get_logger(), "Message received: '%d'", msg->data);
 
   // publish message

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -125,11 +125,11 @@ void Ros2CppNode::setup() {
   parameters_callback_ = this->add_on_set_parameters_callback(std::bind(&Ros2CppNode::parametersCallback, this, std::placeholders::_1));
 
   // subscriber for handling incoming messages
-  subscriber_ = this->create_subscription<std_msgs::msg::Int32>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 
   // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<std_msgs::msg::Int32>("~/output", 10);
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 
   // service server for handling service calls
@@ -147,23 +147,24 @@ void Ros2CppNode::setup() {
   // setup diagnostic updater
   diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("Health", this, &Ros2CppNode::health);
-  topic_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
+  topic_diagnostic_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_min_frequency_, &topic_diagnostic_max_frequency_, topic_diagnostic_frequency_tolerance_, topic_diagnostic_frequency_window_size_)
+    diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_min_frequency_, &topic_diagnostic_max_frequency_, topic_diagnostic_frequency_tolerance_, topic_diagnostic_frequency_window_size_),
+    diagnostic_updater::TimeStampStatusParam(topic_diagnostic_min_acceptable_stamp_delta_, topic_diagnostic_max_acceptable_stamp_delta_)
   );
 }
 
 
-void Ros2CppNode::topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg) {
+void Ros2CppNode::topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg) {
 
-  topic_diagnostic_->tick();
-  RCLCPP_INFO(this->get_logger(), "Message received: '%d'", msg->data);
+  topic_diagnostic_->tick(msg->header.stamp);
+  RCLCPP_INFO(this->get_logger(), "Message received with stamp: '%d'", msg->header.stamp.sec);
 
   // publish message
-  std_msgs::msg::Int32::UniquePtr out_msg = std::make_unique<std_msgs::msg::Int32>();
-  out_msg->data = msg->data;
-  RCLCPP_INFO(this->get_logger(), "Message published: '%d'", out_msg->data);
+  geometry_msgs::msg::PointStamped::UniquePtr out_msg = std::make_unique<geometry_msgs::msg::PointStamped>();
+  *out_msg = *msg;
+  RCLCPP_INFO(this->get_logger(), "Message published with stamp: '%d'", out_msg->header.stamp.sec);
   publisher_->publish(std::move(out_msg));
 }
 

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -146,7 +146,7 @@ void Ros2CppNode::setup() {
 
   // setup diagnostic updater
   diagnostic_updater_.setHardwareID("none");
-  diagnostic_updater_.add("ros2_cpp_node Status", this, &Ros2CppNode::diagnostics);
+  diagnostic_updater_.add("Health", this, &Ros2CppNode::health);
   subscriber_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
@@ -260,7 +260,7 @@ void Ros2CppNode::timerCallback() {
 }
 
 
-void Ros2CppNode::diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat) {
+void Ros2CppNode::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
   // TODO: fill diagnostic status message appropriately based on current system state
   if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -147,17 +147,23 @@ void Ros2CppNode::setup() {
   // setup diagnostic updater
   diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("Health", this, &Ros2CppNode::health);
+
+  // add diagnostic task for monitoring topic subscription with a moving average over min. 5 incoming messages based on expected minimum frequency
+  const int topic_diagnostic_frequency_window_size = std::ceil(5 / (diagnostic_updater_.getPeriod().seconds() * topic_diagnostic_config_.min_frequency));
   topic_diagnostic_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_min_frequency_, &topic_diagnostic_max_frequency_, topic_diagnostic_frequency_tolerance_, topic_diagnostic_frequency_window_size_),
-    diagnostic_updater::TimeStampStatusParam(topic_diagnostic_min_acceptable_stamp_delta_, topic_diagnostic_max_acceptable_stamp_delta_)
+    diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_config_.min_frequency, &topic_diagnostic_config_.max_frequency, 0.0, topic_diagnostic_frequency_window_size),
+    diagnostic_updater::TimeStampStatusParam(topic_diagnostic_config_.min_acceptable_timestamp_delta, topic_diagnostic_config_.max_acceptable_timestamp_delta)
   );
+
+  // add diagnostic task for monitoring topic publisher with a moving average over min. 5 incoming messages based on expected minimum frequency
+  const int diagnosed_publisher_frequency_window_size = std::ceil(5 / (diagnostic_updater_.getPeriod().seconds() * diagnosed_publisher_config_.min_frequency));
   diagnosed_publisher_ = std::make_unique<diagnostic_updater::DiagnosedPublisher<geometry_msgs::msg::PointStamped>>(
     publisher_,
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&diagnosed_publisher_min_frequency_, &diagnosed_publisher_max_frequency_, diagnosed_publisher_frequency_tolerance_, diagnosed_publisher_frequency_window_size_),
-    diagnostic_updater::TimeStampStatusParam(diagnosed_publisher_min_acceptable_stamp_delta_, diagnosed_publisher_max_acceptable_stamp_delta_)
+    diagnostic_updater::FrequencyStatusParam(&diagnosed_publisher_config_.min_frequency, &diagnosed_publisher_config_.max_frequency, 0.0, diagnosed_publisher_frequency_window_size),
+    diagnostic_updater::TimeStampStatusParam(diagnosed_publisher_config_.min_acceptable_timestamp_delta, diagnosed_publisher_config_.max_acceptable_timestamp_delta)
   );
 }
 
@@ -293,6 +299,14 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Ros2Cp
   RCLCPP_INFO(get_logger(), "Configuring to enter 'inactive' state from '%s' state", state.label().c_str());
 
   this->declareAndLoadParameter("param", param_, "TODO", true, false, false, 0.0, 10.0, 1.0);
+  this->declareAndLoadParameter("topic_diagnostic.min_frequency", topic_diagnostic_config_.min_frequency, "Minimum frequency for incoming messages", true, true, false);
+  this->declareAndLoadParameter("topic_diagnostic.max_frequency", topic_diagnostic_config_.max_frequency, "Maximum frequency for incoming messages", true, true, false);
+  this->declareAndLoadParameter("topic_diagnostic.min_acceptable_timestamp_delta", topic_diagnostic_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for incoming messages", true, true, false);
+  this->declareAndLoadParameter("topic_diagnostic.max_acceptable_timestamp_delta", topic_diagnostic_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnosed_publisher.min_frequency", diagnosed_publisher_config_.min_frequency, "Minimum frequency for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnosed_publisher.max_frequency", diagnosed_publisher_config_.max_frequency, "Maximum frequency for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnosed_publisher.min_acceptable_timestamp_delta", diagnosed_publisher_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnosed_publisher.max_acceptable_timestamp_delta", diagnosed_publisher_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for outgoing messages", true, true, false);
   setup();
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -153,6 +153,12 @@ void Ros2CppNode::setup() {
     diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_min_frequency_, &topic_diagnostic_max_frequency_, topic_diagnostic_frequency_tolerance_, topic_diagnostic_frequency_window_size_),
     diagnostic_updater::TimeStampStatusParam(topic_diagnostic_min_acceptable_stamp_delta_, topic_diagnostic_max_acceptable_stamp_delta_)
   );
+  diagnosed_publisher_ = std::make_unique<diagnostic_updater::DiagnosedPublisher<geometry_msgs::msg::PointStamped>>(
+    publisher_,
+    diagnostic_updater_,
+    diagnostic_updater::FrequencyStatusParam(&diagnosed_publisher_min_frequency_, &diagnosed_publisher_max_frequency_, diagnosed_publisher_frequency_tolerance_, diagnosed_publisher_frequency_window_size_),
+    diagnostic_updater::TimeStampStatusParam(diagnosed_publisher_min_acceptable_stamp_delta_, diagnosed_publisher_max_acceptable_stamp_delta_)
+  );
 }
 
 
@@ -165,7 +171,7 @@ void Ros2CppNode::topicCallback(const geometry_msgs::msg::PointStamped::ConstSha
   geometry_msgs::msg::PointStamped::UniquePtr out_msg = std::make_unique<geometry_msgs::msg::PointStamped>();
   *out_msg = *msg;
   RCLCPP_INFO(this->get_logger(), "Message published with stamp: '%d'", out_msg->header.stamp.sec);
-  publisher_->publish(std::move(out_msg));
+  diagnosed_publisher_->publish(std::move(out_msg));
 }
 
 

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -145,9 +145,8 @@ void Ros2CppNode::setup() {
   );
 
   // setup diagnostic updater
-  diagnostic_updater_.setHardwareID(this->get_name());
+  diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("ros2_cpp_node Status", this, &Ros2CppNode::diagnostics);
-  // optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
   topic_diagnostic_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
     "~/input",
     diagnostic_updater_,

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -264,7 +264,19 @@ void Ros2CppNode::timerCallback() {
 void Ros2CppNode::diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
   // TODO: fill diagnostic status message appropriately based on current system state
-  stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is running properly");
+  if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.");
+    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+  } else if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.");
+    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  } else if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::OK) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is able to assess its own performance level and is reaching its desired performance level.");
+    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+  } else {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "Node performance level cannot be assessed");
+    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+  }
   // optional: add custom key-value pairs to diagnostics status
   stat.add("Dummy Status Key", "Dummy Status Value");
 }

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -147,17 +147,17 @@ void Ros2CppNode::setup() {
   // setup diagnostic updater
   diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("Health", this, &Ros2CppNode::health);
-  subscriber_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
+  topic_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&subscriber_diagnostic_params_.min_frequency, &subscriber_diagnostic_params_.max_frequency, subscriber_diagnostic_params_.frequency_tolerance, subscriber_diagnostic_params_.frequency_window_size)
+    diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_min_frequency_, &topic_diagnostic_max_frequency_, topic_diagnostic_frequency_tolerance_, topic_diagnostic_frequency_window_size_)
   );
 }
 
 
 void Ros2CppNode::topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg) {
 
-  subscriber_diagnostic_->tick();
+  topic_diagnostic_->tick();
   RCLCPP_INFO(this->get_logger(), "Message received: '%d'", msg->data);
 
   // publish message

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -147,11 +147,10 @@ void Ros2CppNode::setup() {
   // setup diagnostic updater
   diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("ros2_cpp_node Status", this, &Ros2CppNode::diagnostics);
-  topic_diagnostic_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
+  subscriber_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&min_freq_, &max_freq_),
-    diagnostic_updater::TimeStampStatusParam(min_delta_stamp_, max_delta_stamp_)
+    diagnostic_updater::FrequencyStatusParam(&subscriber_diagnostic_params_.freq_min, &subscriber_diagnostic_params_.freq_max, subscriber_diagnostic_params_.freq_tolerance, subscriber_diagnostic_params_.freq_window_size)
   );
 }
 

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -143,6 +143,11 @@ void Ros2CppNode::setup() {
     std::bind(&Ros2CppNode::actionHandleCancel, this, std::placeholders::_1),
     std::bind(&Ros2CppNode::actionHandleAccepted, this, std::placeholders::_1)
   );
+
+  // setup diagnostic updater
+  diagnostic_updater_.setHardwareID(this->get_name());
+  diagnostic_updater_.add("ros2_cpp_node diagnostics", this, &Ros2CppNode::diagnostics);
+  // optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
 }
 
 
@@ -247,6 +252,15 @@ void Ros2CppNode::actionExecute(const std::shared_ptr<rclcpp_action::ServerGoalH
 void Ros2CppNode::timerCallback() {
 
   RCLCPP_INFO(this->get_logger(), "Timer triggered");
+}
+
+
+void Ros2CppNode::diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat) {
+
+  // TODO: fill diagnostic status message appropriately based on current system state
+  stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is running properly");
+  // optional: add custom key-value pairs to diagnostics status
+  stat.add("Dummy Status Key", "Dummy Status Value");
 }
 
 

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -148,6 +148,12 @@ void Ros2CppNode::setup() {
   diagnostic_updater_.setHardwareID(this->get_name());
   diagnostic_updater_.add("ros2_cpp_node Status", this, &Ros2CppNode::diagnostics);
   // optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
+  topic_diagnostic_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
+    "~/input",
+    diagnostic_updater_,
+    diagnostic_updater::FrequencyStatusParam(&min_freq_, &max_freq_),
+    diagnostic_updater::TimeStampStatusParam(min_delta_stamp_, max_delta_stamp_)
+  );
 }
 
 

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -150,7 +150,7 @@ void Ros2CppNode::setup() {
   subscriber_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&subscriber_diagnostic_params_.freq_min, &subscriber_diagnostic_params_.freq_max, subscriber_diagnostic_params_.freq_tolerance, subscriber_diagnostic_params_.freq_window_size)
+    diagnostic_updater::FrequencyStatusParam(&subscriber_diagnostic_params_.min_frequency, &subscriber_diagnostic_params_.max_frequency, subscriber_diagnostic_params_.frequency_tolerance, subscriber_diagnostic_params_.frequency_window_size)
   );
 }
 
@@ -263,18 +263,18 @@ void Ros2CppNode::timerCallback() {
 void Ros2CppNode::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
   // TODO: fill diagnostic status message appropriately based on current system state
-  if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+  if(health_ == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.");
-    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-  } else if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
+    health_ = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+  } else if(health_ == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.");
-    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  } else if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::OK) {
+    health_ = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  } else if(health_ == diagnostic_msgs::msg::DiagnosticStatus::OK) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is able to assess its own performance level and is reaching its desired performance level.");
-    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+    health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
   } else {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "Node performance level cannot be assessed");
-    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    health_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
   }
   // optional: add custom key-value pairs to diagnostics status
   stat.add("Dummy Status Key", "Dummy Status Value");

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -146,7 +146,7 @@ void Ros2CppNode::setup() {
 
   // setup diagnostic updater
   diagnostic_updater_.setHardwareID(this->get_name());
-  diagnostic_updater_.add("ros2_cpp_node diagnostics", this, &Ros2CppNode::diagnostics);
+  diagnostic_updater_.add("ros2_cpp_node Status", this, &Ros2CppNode::diagnostics);
   // optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
 }
 

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -310,14 +310,14 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Ros2Cp
   RCLCPP_INFO(get_logger(), "Configuring to enter 'inactive' state from '%s' state", state.label().c_str());
 
   this->declareAndLoadParameter("param", param_, "TODO", true, false, false, 0.0, 10.0, 1.0);
-  this->declareAndLoadParameter("topic_diagnostic.min_frequency", topic_diagnostic_config_.min_frequency, "Minimum frequency for incoming messages", true, true, false);
-  this->declareAndLoadParameter("topic_diagnostic.max_frequency", topic_diagnostic_config_.max_frequency, "Maximum frequency for incoming messages", true, true, false);
-  this->declareAndLoadParameter("topic_diagnostic.min_acceptable_timestamp_delta", topic_diagnostic_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for incoming messages", true, true, false);
-  this->declareAndLoadParameter("topic_diagnostic.max_acceptable_timestamp_delta", topic_diagnostic_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for incoming messages", true, true, false);
-  this->declareAndLoadParameter("diagnosed_publisher.min_frequency", diagnosed_publisher_config_.min_frequency, "Minimum frequency for outgoing messages", true, true, false);
-  this->declareAndLoadParameter("diagnosed_publisher.max_frequency", diagnosed_publisher_config_.max_frequency, "Maximum frequency for outgoing messages", true, true, false);
-  this->declareAndLoadParameter("diagnosed_publisher.min_acceptable_timestamp_delta", diagnosed_publisher_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for outgoing messages", true, true, false);
-  this->declareAndLoadParameter("diagnosed_publisher.max_acceptable_timestamp_delta", diagnosed_publisher_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.min_frequency", topic_diagnostic_config_.min_frequency, "Minimum frequency for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.max_frequency", topic_diagnostic_config_.max_frequency, "Maximum frequency for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.min_acceptable_timestamp_delta", topic_diagnostic_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.max_acceptable_timestamp_delta", topic_diagnostic_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.min_frequency", diagnosed_publisher_config_.min_frequency, "Minimum frequency for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.max_frequency", diagnosed_publisher_config_.max_frequency, "Maximum frequency for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.min_acceptable_timestamp_delta", diagnosed_publisher_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.max_acceptable_timestamp_delta", diagnosed_publisher_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for outgoing messages", true, true, false);
   setup();
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -270,10 +270,6 @@ void Ros2CppNode::actionExecute(const std::shared_ptr<rclcpp_action::ServerGoalH
 void Ros2CppNode::timerCallback() {
 
   RCLCPP_INFO(this->get_logger(), "Timer triggered");
-}
-
-
-void Ros2CppNode::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
   // TODO: Remove this demonstration of health status and implement real health checks using `setHealth()`
   if(health_.status == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
@@ -290,6 +286,10 @@ void Ros2CppNode::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
     health_.status = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
   }
   // end of demonstration
+}
+
+
+void Ros2CppNode::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
   stat.summary(health_.status, health_.message);
   for (const auto& [key, value] : health_.key_value_pairs) {
@@ -299,9 +299,11 @@ void Ros2CppNode::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
 
 void Ros2CppNode::setHealth(const unsigned char status, const std::string& msg, const std::map<std::string, std::string>& key_value_pairs) {
+
   health_.status = status;
   health_.message = msg;
   health_.key_value_pairs = key_value_pairs;
+  diagnostic_updater_.force_update();
 }
 
 

--- a/samples/ros2_cpp_component_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_component_pkg/CMakeLists.txt
@@ -6,9 +6,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
-find_package(std_msgs REQUIRED)
 
 set(TARGET_NAME ros2_cpp_node_component)
 
@@ -28,8 +28,8 @@ target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
 target_link_libraries(${TARGET_NAME} PUBLIC
   rclcpp::rclcpp
+  ${geometry_msgs_TARGETS}
   ${rclcpp_components_TARGETS}
-  ${std_msgs_TARGETS}
 )
 
 install(TARGETS ${TARGET_NAME}

--- a/samples/ros2_cpp_component_pkg/include/ros2_cpp_component_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_component_pkg/include/ros2_cpp_component_pkg/ros2_cpp_node.hpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
+#include <geometry_msgs/msg/point_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/int32.hpp>
 
 
 namespace ros2_cpp_component_pkg {
@@ -75,7 +75,7 @@ class Ros2CppNode : public rclcpp::Node {
    *
    * @param msg message
    */
-  void topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg);
+  void topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg);
 
  private:
 
@@ -92,12 +92,12 @@ class Ros2CppNode : public rclcpp::Node {
   /**
    * @brief Subscriber
    */
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr subscriber_;
+  rclcpp::Subscription<geometry_msgs::msg::PointStamped>::SharedPtr subscriber_;
 
   /**
    * @brief Publisher
    */
-  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr publisher_;
+  rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr publisher_;
 
   /**
    * @brief Dummy parameter (parameter)

--- a/samples/ros2_cpp_component_pkg/package.xml
+++ b/samples/ros2_cpp_component_pkg/package.xml
@@ -13,9 +13,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>std_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/samples/ros2_cpp_component_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_component_pkg/src/ros2_cpp_node.cpp
@@ -118,23 +118,23 @@ void Ros2CppNode::setup() {
   parameters_callback_ = this->add_on_set_parameters_callback(std::bind(&Ros2CppNode::parametersCallback, this, std::placeholders::_1));
 
   // subscriber for handling incoming messages
-  subscriber_ = this->create_subscription<std_msgs::msg::Int32>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 
   // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<std_msgs::msg::Int32>("~/output", 10);
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 }
 
 
-void Ros2CppNode::topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg) {
+void Ros2CppNode::topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg) {
 
-  RCLCPP_INFO(this->get_logger(), "Message received: '%d'", msg->data);
+  RCLCPP_INFO(this->get_logger(), "Message received with stamp: '%d'", msg->header.stamp.sec);
 
   // publish message
-  std_msgs::msg::Int32::UniquePtr out_msg = std::make_unique<std_msgs::msg::Int32>();
-  out_msg->data = msg->data;
-  RCLCPP_INFO(this->get_logger(), "Message published: '%d'", out_msg->data);
+  geometry_msgs::msg::PointStamped::UniquePtr out_msg = std::make_unique<geometry_msgs::msg::PointStamped>();
+  *out_msg = *msg;
+  RCLCPP_INFO(this->get_logger(), "Message published with stamp: '%d'", out_msg->header.stamp.sec);
   publisher_->publish(std::move(out_msg));
 }
 

--- a/samples/ros2_cpp_lifecycle_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_lifecycle_pkg/CMakeLists.txt
@@ -6,9 +6,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
-find_package(std_msgs REQUIRED)
 
 set(TARGET_NAME ros2_cpp_node)
 
@@ -22,8 +22,8 @@ target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
 target_link_libraries(${TARGET_NAME} PUBLIC
   rclcpp::rclcpp
+  ${geometry_msgs_TARGETS}
   ${rclcpp_lifecycle_TARGETS}
-  ${std_msgs_TARGETS}
 )
 
 install(TARGETS ${TARGET_NAME}

--- a/samples/ros2_cpp_lifecycle_pkg/include/ros2_cpp_lifecycle_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_lifecycle_pkg/include/ros2_cpp_lifecycle_pkg/ros2_cpp_node.hpp
@@ -4,12 +4,12 @@
 #include <string>
 #include <vector>
 
+#include <geometry_msgs/msg/point_stamped.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 #include <lifecycle_msgs/msg/transition.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <rclcpp_lifecycle/lifecycle_publisher.hpp>
-#include <std_msgs/msg/int32.hpp>
 
 
 namespace ros2_cpp_lifecycle_pkg {
@@ -116,7 +116,7 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
    *
    * @param msg message
    */
-  void topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg);
+  void topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg);
 
  private:
 
@@ -133,12 +133,12 @@ class Ros2CppNode : public rclcpp_lifecycle::LifecycleNode {
   /**
    * @brief Subscriber
    */
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr subscriber_;
+  rclcpp::Subscription<geometry_msgs::msg::PointStamped>::SharedPtr subscriber_;
 
   /**
    * @brief Publisher
    */
-  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Int32>::SharedPtr publisher_;
+  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PointStamped>::SharedPtr publisher_;
 
   /**
    * @brief Dummy parameter (parameter)

--- a/samples/ros2_cpp_lifecycle_pkg/package.xml
+++ b/samples/ros2_cpp_lifecycle_pkg/package.xml
@@ -13,9 +13,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
-  <depend>std_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/samples/ros2_cpp_lifecycle_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_lifecycle_pkg/src/ros2_cpp_node.cpp
@@ -120,24 +120,24 @@ void Ros2CppNode::setup() {
   parameters_callback_ = this->add_on_set_parameters_callback(std::bind(&Ros2CppNode::parametersCallback, this, std::placeholders::_1));
 
   // subscriber for handling incoming messages
-  subscriber_ = this->create_subscription<std_msgs::msg::Int32>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 
   // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<std_msgs::msg::Int32>("~/output", 10);
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 }
 
 
-void Ros2CppNode::topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg) {
+void Ros2CppNode::topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg) {
 
-  RCLCPP_INFO(this->get_logger(), "Message received: '%d'", msg->data);
+  RCLCPP_INFO(this->get_logger(), "Message received with stamp: '%d'", msg->header.stamp.sec);
 
   // publish message
-  std_msgs::msg::Int32 out_msg;
-  out_msg.data = msg->data;
+  geometry_msgs::msg::PointStamped out_msg;
+  out_msg = *msg;
   publisher_->publish(out_msg);
-  RCLCPP_INFO(this->get_logger(), "Message published: '%d'", out_msg.data);
+  RCLCPP_INFO(this->get_logger(), "Message published with stamp: '%d'", out_msg.header.stamp.sec);
 }
 
 

--- a/samples/ros2_cpp_multi_threaded_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_multi_threaded_pkg/CMakeLists.txt
@@ -6,8 +6,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
 
 set(TARGET_NAME ros2_cpp_node)
 
@@ -21,7 +21,7 @@ target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
 target_link_libraries(${TARGET_NAME} PUBLIC
   rclcpp::rclcpp
-  ${std_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
 )
 
 install(TARGETS ${TARGET_NAME}

--- a/samples/ros2_cpp_multi_threaded_pkg/include/ros2_cpp_multi_threaded_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_multi_threaded_pkg/include/ros2_cpp_multi_threaded_pkg/ros2_cpp_node.hpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
+#include <geometry_msgs/msg/point_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/int32.hpp>
 
 
 namespace ros2_cpp_multi_threaded_pkg {
@@ -75,7 +75,7 @@ class Ros2CppNode : public rclcpp::Node {
    *
    * @param msg message
    */
-  void topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg);
+  void topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg);
 
  private:
 
@@ -92,12 +92,12 @@ class Ros2CppNode : public rclcpp::Node {
   /**
    * @brief Subscriber
    */
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr subscriber_;
+  rclcpp::Subscription<geometry_msgs::msg::PointStamped>::SharedPtr subscriber_;
 
   /**
    * @brief Publisher
    */
-  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr publisher_;
+  rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr publisher_;
 
   /**
    * @brief Dummy parameter (parameter)

--- a/samples/ros2_cpp_multi_threaded_pkg/package.xml
+++ b/samples/ros2_cpp_multi_threaded_pkg/package.xml
@@ -13,8 +13,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/samples/ros2_cpp_multi_threaded_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_multi_threaded_pkg/src/ros2_cpp_node.cpp
@@ -121,24 +121,24 @@ void Ros2CppNode::setup() {
   subscriber_options.callback_group = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   // subscriber for handling incoming messages
-  subscriber_ = this->create_subscription<std_msgs::msg::Int32>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1), subscriber_options);
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1), subscriber_options);
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 
   // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<std_msgs::msg::Int32>("~/output", 10);
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 }
 
 
-void Ros2CppNode::topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg) {
+void Ros2CppNode::topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg) {
 
-  RCLCPP_INFO(this->get_logger(), "Message received: '%d'", msg->data);
+  RCLCPP_INFO(this->get_logger(), "Message received with stamp: '%d'", msg->header.stamp.sec);
 
   // publish message
-  std_msgs::msg::Int32 out_msg;
-  out_msg.data = msg->data;
+  geometry_msgs::msg::PointStamped out_msg;
+  out_msg = *msg;
   publisher_->publish(out_msg);
-  RCLCPP_INFO(this->get_logger(), "Message published: '%d'", out_msg.data);
+  RCLCPP_INFO(this->get_logger(), "Message published with stamp: '%d'", out_msg.header.stamp.sec);
 }
 
 

--- a/samples/ros2_cpp_pkg/CMakeLists.txt
+++ b/samples/ros2_cpp_pkg/CMakeLists.txt
@@ -6,8 +6,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
 
 set(TARGET_NAME ros2_cpp_node)
 
@@ -21,7 +21,7 @@ target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
 target_link_libraries(${TARGET_NAME} PUBLIC
   rclcpp::rclcpp
-  ${std_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
 )
 
 install(TARGETS ${TARGET_NAME}

--- a/samples/ros2_cpp_pkg/include/ros2_cpp_pkg/ros2_cpp_node.hpp
+++ b/samples/ros2_cpp_pkg/include/ros2_cpp_pkg/ros2_cpp_node.hpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
+#include <geometry_msgs/msg/point_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/int32.hpp>
 
 
 namespace ros2_cpp_pkg {
@@ -70,7 +70,7 @@ class Ros2CppNode : public rclcpp::Node {
    *
    * @param msg message
    */
-  void topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg);
+  void topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg);
 
  private:
 
@@ -87,12 +87,12 @@ class Ros2CppNode : public rclcpp::Node {
   /**
    * @brief Subscriber
    */
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr subscriber_;
+  rclcpp::Subscription<geometry_msgs::msg::PointStamped>::SharedPtr subscriber_;
 
   /**
    * @brief Publisher
    */
-  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr publisher_;
+  rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr publisher_;
 
   /**
    * @brief Dummy parameter (parameter)

--- a/samples/ros2_cpp_pkg/package.xml
+++ b/samples/ros2_cpp_pkg/package.xml
@@ -13,8 +13,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/samples/ros2_cpp_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_pkg/src/ros2_cpp_node.cpp
@@ -115,24 +115,24 @@ void Ros2CppNode::setup() {
   parameters_callback_ = this->add_on_set_parameters_callback(std::bind(&Ros2CppNode::parametersCallback, this, std::placeholders::_1));
 
   // subscriber for handling incoming messages
-  subscriber_ = this->create_subscription<std_msgs::msg::Int32>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 
   // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<std_msgs::msg::Int32>("~/output", 10);
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 }
 
 
-void Ros2CppNode::topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg) {
+void Ros2CppNode::topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg) {
 
-  RCLCPP_INFO(this->get_logger(), "Message received: '%d'", msg->data);
+  RCLCPP_INFO(this->get_logger(), "Message received with stamp: '%d'", msg->header.stamp.sec);
 
   // publish message
-  std_msgs::msg::Int32 out_msg;
-  out_msg.data = msg->data;
+  geometry_msgs::msg::PointStamped out_msg;
+  out_msg = *msg;
   publisher_->publish(out_msg);
-  RCLCPP_INFO(this->get_logger(), "Message published: '%d'", out_msg.data);
+  RCLCPP_INFO(this->get_logger(), "Message published with stamp: '%d'", out_msg.header.stamp.sec);
 }
 
 

--- a/samples/ros2_python_all_pkg/config/params.yml
+++ b/samples/ros2_python_all_pkg/config/params.yml
@@ -1,3 +1,4 @@
 /**/*:
   ros__parameters:
+    diagnostic_updater.period: 0.1
     param: 1.0

--- a/samples/ros2_python_all_pkg/config/params.yml
+++ b/samples/ros2_python_all_pkg/config/params.yml
@@ -1,4 +1,6 @@
 /**/*:
   ros__parameters:
-    diagnostic_updater.period: 0.1
+    diagnostic_updater:
+      period: 0.1
+      use_fqn: false
     param: 1.0

--- a/samples/ros2_python_all_pkg/package.xml
+++ b/samples/ros2_python_all_pkg/package.xml
@@ -12,6 +12,7 @@
   <license>TODO</license>
 
   <depend>rclpy</depend>
+  <depend>diagnostic_updater</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>ros2_python_all_pkg_interfaces</depend>

--- a/samples/ros2_python_all_pkg/package.xml
+++ b/samples/ros2_python_all_pkg/package.xml
@@ -11,8 +11,8 @@
 
   <license>TODO</license>
 
-  <depend>rclpy</depend>
   <depend>diagnostic_updater</depend>
+  <depend>rclpy</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>ros2_python_all_pkg_interfaces</depend>

--- a/samples/ros2_python_all_pkg/package.xml
+++ b/samples/ros2_python_all_pkg/package.xml
@@ -12,8 +12,8 @@
   <license>TODO</license>
 
   <depend>diagnostic_updater</depend>
+  <depend>geometry_msgs</depend>
   <depend>rclpy</depend>
-  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>ros2_python_all_pkg_interfaces</depend>
 

--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -11,6 +11,7 @@ from std_srvs.srv import SetBool
 from ros2_python_all_pkg_interfaces.action import Fibonacci
 from diagnostic_msgs.msg import DiagnosticStatus
 from diagnostic_updater import Updater
+from diagnostic_updater import TopicDiagnostic, FrequencyStatusParam, TimeStampStatusParam
 
 
 class Ros2PythonNode(Node):
@@ -166,6 +167,13 @@ class Ros2PythonNode(Node):
         self.diagnostic_updater.setHardwareID(self.get_name())
         self.diagnostic_updater.add("ros2_python_node Status", self.diagnostics)
         # optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
+        self.freq_bound_ = {"min": 0.5, "max": 5.0}
+        self.topic_diagnostic = TopicDiagnostic(
+            "~/input",
+            self.diagnostic_updater,
+            FrequencyStatusParam(self.freq_bound_),
+            TimeStampStatusParam(-0.1, 0.1)
+        )
 
     def topic_callback(self, msg: Int32):
         """Processes messages received by a subscriber

--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -166,6 +166,7 @@ class Ros2PythonNode(Node):
         self.diagnostic_updater = Updater(self)
         self.diagnostic_updater.setHardwareID(self.get_name())
         self.diagnostic_updater.add("ros2_python_node Status", self.diagnostics)
+        self.system_status_ = DiagnosticStatus.STALE
         # optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
         self.freq_bound_ = {"min": 0.5, "max": 5.0}
         self.topic_diagnostic = TopicDiagnostic(
@@ -299,7 +300,18 @@ class Ros2PythonNode(Node):
         """
 
         # TODO: fill diagnostic status message appropriately based on current system state
-        stat.summary(DiagnosticStatus.OK, "Node is running properly")
+        if self.system_status_ == DiagnosticStatus.ERROR:
+            stat.summary(DiagnosticStatus.ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.")
+            self.system_status_ = DiagnosticStatus.WARN
+        elif self.system_status_ == DiagnosticStatus.WARN:
+            stat.summary(DiagnosticStatus.WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.")
+            self.system_status_ = DiagnosticStatus.OK
+        elif self.system_status_ == DiagnosticStatus.OK:
+            stat.summary(DiagnosticStatus.OK, "Node is able to assess its own performance level and is reaching its desired performance level.")
+            self.system_status_ = DiagnosticStatus.STALE
+        else:
+            stat.summary(DiagnosticStatus.STALE, "Node performance level cannot be assessed")
+            self.system_status_ = DiagnosticStatus.ERROR
         # optional: add custom key-value pairs to diagnostics status
         stat.add("Dummy Status Key", "Dummy Status Value")
 

--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -9,6 +9,8 @@ from rcl_interfaces.msg import (FloatingPointRange, IntegerRange, ParameterDescr
 from std_msgs.msg import Int32
 from std_srvs.srv import SetBool
 from ros2_python_all_pkg_interfaces.action import Fibonacci
+from diagnostic_msgs.msg import DiagnosticStatus
+from diagnostic_updater import Updater
 
 
 class Ros2PythonNode(Node):
@@ -159,6 +161,12 @@ class Ros2PythonNode(Node):
         # timer for repeatedly invoking a callback to publish messages
         self.timer = self.create_timer(1.0, self.timer_callback)
 
+        # setup diagnostic updater
+        self.diagnostic_updater = Updater(self)
+        self.diagnostic_updater.setHardwareID(self.get_name())
+        self.diagnostic_updater.add("ros2_python_node Status", self.diagnostics)
+        # optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
+
     def topic_callback(self, msg: Int32):
         """Processes messages received by a subscriber
 
@@ -277,6 +285,17 @@ class Ros2PythonNode(Node):
         """
 
         self.get_logger().info("Timer triggered")
+
+    def diagnostics(self, stat):
+        """Function called by diagnostic updater to populate diagnostics status
+        """
+
+        # TODO: fill diagnostic status message appropriately based on current system state
+        stat.summary(DiagnosticStatus.OK, "Node is running properly")
+        # optional: add custom key-value pairs to diagnostics status
+        stat.add("Dummy Status Key", "Dummy Status Value")
+
+        return stat
 
 
 def main():

--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -351,10 +351,6 @@ class Ros2PythonNode(Node):
 
         self.get_logger().info("Timer triggered")
 
-    def health(self, stat: DiagnosticStatusWrapper) -> DiagnosticStatusWrapper:
-        """Function called by diagnostic updater to populate diagnostics status
-        """
-
         # TODO: Remove this demonstration of health status and implement real health checks using `setHealth()`
         if self.health_.status == DiagnosticStatus.ERROR:
             self.setHealth(DiagnosticStatus.ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.", {"uptime": f"{self.get_clock().now().nanoseconds / 1e9}"})
@@ -369,6 +365,10 @@ class Ros2PythonNode(Node):
             self.setHealth(DiagnosticStatus.STALE, "Node performance level cannot be assessed")
             self.health_.status = DiagnosticStatus.ERROR
         # end of demonstration
+
+    def health(self, stat: DiagnosticStatusWrapper) -> DiagnosticStatusWrapper:
+        """Function called by diagnostic updater to populate diagnostics status
+        """
 
         stat.summary(self.health_.status, self.health_.msg)
         if self.health_.key_value_pairs is not None:
@@ -386,6 +386,7 @@ class Ros2PythonNode(Node):
         """
 
         self.health_ = Health(status, msg, key_value_pairs)
+        self.diagnostic_updater.force_update()
 
 
 def main():

--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -1,17 +1,32 @@
 import time
 from typing import Any, Optional, Union
 
+from diagnostic_msgs.msg import DiagnosticStatus
+from diagnostic_updater import Updater
+from diagnostic_updater import TopicDiagnostic, FrequencyStatusParam, TimeStampStatusParam, DiagnosticStatusWrapper
+from diagnostic_updater import DiagnosedPublisher
+from geometry_msgs.msg import PointStamped
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.node import Node
 import rclpy.exceptions
 from rcl_interfaces.msg import (FloatingPointRange, IntegerRange, ParameterDescriptor, SetParametersResult)
-from std_msgs.msg import Int32
 from std_srvs.srv import SetBool
 from ros2_python_all_pkg_interfaces.action import Fibonacci
-from diagnostic_msgs.msg import DiagnosticStatus
-from diagnostic_updater import Updater
-from diagnostic_updater import TopicDiagnostic, FrequencyStatusParam, TimeStampStatusParam
+
+
+class TopicDiagnosticConfig:
+    def __init__(self, min_frequency: float, max_frequency: float, min_acceptable_timestamp_delta: float, max_acceptable_timestamp_delta: float):
+        self.min_frequency = min_frequency
+        self.max_frequency = max_frequency
+        self.min_acceptable_timestamp_delta = min_acceptable_timestamp_delta
+        self.max_acceptable_timestamp_delta = max_acceptable_timestamp_delta
+
+class Health:
+    def __init__(self, status: DiagnosticStatus, msg: str, key_value_pairs: Optional[dict[str, str]] = None):
+        self.status = status
+        self.msg = msg
+        self.key_value_pairs = key_value_pairs
 
 
 class Ros2PythonNode(Node):
@@ -32,6 +47,34 @@ class Ros2PythonNode(Node):
                                                     from_value=0.0,
                                                     to_value=10.0,
                                                     step_value=0.1)
+        self.topic_diagnostic_config = TopicDiagnosticConfig(
+            min_frequency=self.declare_and_load_parameter(name="diagnostic_updater.topic_diagnostic.min_frequency",
+                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                          description="Minimum frequency for incoming messages"),
+            max_frequency=self.declare_and_load_parameter(name="diagnostic_updater.topic_diagnostic.max_frequency",
+                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                          description="Maximum frequency for incoming messages"),
+            min_acceptable_timestamp_delta=self.declare_and_load_parameter(name="diagnostic_updater.topic_diagnostic.min_acceptable_timestamp_delta",
+                                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                                          description="Minimum acceptable timestamp delta for incoming messages"),
+            max_acceptable_timestamp_delta=self.declare_and_load_parameter(name="diagnostic_updater.topic_diagnostic.max_acceptable_timestamp_delta",
+                                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                                          description="Maximum acceptable timestamp delta for incoming messages")
+        )
+        self.diagnosed_publisher_config = TopicDiagnosticConfig(
+            min_frequency=self.declare_and_load_parameter(name="diagnostic_updater.diagnosed_publisher.min_frequency",
+                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                          description="Minimum frequency for outgoing messages"),
+            max_frequency=self.declare_and_load_parameter(name="diagnostic_updater.diagnosed_publisher.max_frequency",
+                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                          description="Maximum frequency for outgoing messages"),
+            min_acceptable_timestamp_delta=self.declare_and_load_parameter(name="diagnostic_updater.diagnosed_publisher.min_acceptable_timestamp_delta",
+                                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                                          description="Minimum acceptable timestamp delta for outgoing messages"),
+            max_acceptable_timestamp_delta=self.declare_and_load_parameter(name="diagnostic_updater.diagnosed_publisher.max_acceptable_timestamp_delta",
+                                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                                          description="Maximum acceptable timestamp delta for outgoing messages")
+        )
 
         self.setup()
 
@@ -133,14 +176,14 @@ class Ros2PythonNode(Node):
         self.add_on_set_parameters_callback(self.parameters_callback)
 
         # subscriber for handling incoming messages
-        self.subscriber = self.create_subscription(Int32,
+        self.subscriber = self.create_subscription(PointStamped,
                                                    "~/input",
                                                    self.topic_callback,
                                                    qos_profile=10)
         self.get_logger().info(f"Subscribed to '{self.subscriber.topic_name}'")
 
         # publisher for publishing outgoing messages
-        self.publisher = self.create_publisher(Int32,
+        self.publisher = self.create_publisher(PointStamped,
                                                "~/output",
                                                qos_profile=10)
         self.get_logger().info(f"Publishing to '{self.publisher.topic_name}'")
@@ -165,25 +208,37 @@ class Ros2PythonNode(Node):
         # setup diagnostic updater
         self.diagnostic_updater = Updater(self)
         self.diagnostic_updater.setHardwareID(self.get_name())
-        self.diagnostic_updater.add("ros2_python_node Status", self.diagnostics)
-        self.system_status_ = DiagnosticStatus.STALE
-        # optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
-        self.freq_bound_ = {"min": 0.5, "max": 5.0}
+        self.diagnostic_updater.add("Health", self.health)
+        self.health_ = Health(DiagnosticStatus.STALE, "")
+        # add diagnostic task for monitoring topic subscription with a moving average over min. 5 incoming messages based on expected minimum frequency
+        from math import ceil
+        topic_diagnostic_frequency_window_size = ceil(5 / (self.diagnostic_updater.period * self.topic_diagnostic_config.min_frequency))
         self.topic_diagnostic = TopicDiagnostic(
             "~/input",
             self.diagnostic_updater,
-            FrequencyStatusParam(self.freq_bound_),
-            TimeStampStatusParam(-0.1, 0.1)
+            FrequencyStatusParam({"min": self.topic_diagnostic_config.min_frequency, "max": self.topic_diagnostic_config.max_frequency}, 0.0, topic_diagnostic_frequency_window_size),
+            TimeStampStatusParam(self.topic_diagnostic_config.min_acceptable_timestamp_delta, self.topic_diagnostic_config.max_acceptable_timestamp_delta)
+        )
+        # add diagnostic task for monitoring topic publisher with a moving average over min. 5 incoming messages based on expected minimum frequency
+        from math import ceil
+        diagnosed_publisher_frequency_window_size = ceil(5 / (self.diagnostic_updater.period * self.diagnosed_publisher_config.min_frequency))
+        self.diagnosed_publisher = DiagnosedPublisher(
+            self.publisher,
+            self.diagnostic_updater,
+            FrequencyStatusParam({"min": self.diagnosed_publisher_config.min_frequency, "max": self.diagnosed_publisher_config.max_frequency}, 0.0, diagnosed_publisher_frequency_window_size),
+            TimeStampStatusParam(self.diagnosed_publisher_config.min_acceptable_timestamp_delta, self.diagnosed_publisher_config.max_acceptable_timestamp_delta)
         )
 
-    def topic_callback(self, msg: Int32):
+    def topic_callback(self, msg: PointStamped):
         """Processes messages received by a subscriber
 
         Args:
-            msg (Int32): message
+            msg (PointStamped): message
         """
 
-        self.get_logger().info(f"Message received: '{msg.data}'")
+        self.topic_diagnostic.tick(rclpy.time.Time.from_msg(msg.header.stamp))
+        self.get_logger().info(f"Message received with stamp: '{msg.header.stamp}'")
+        self.diagnosed_publisher.publish(msg)
 
     def service_callback(self, request: SetBool.Request, response: SetBool.Response) -> SetBool.Response:
         """Processes service requests
@@ -295,27 +350,41 @@ class Ros2PythonNode(Node):
 
         self.get_logger().info("Timer triggered")
 
-    def diagnostics(self, stat):
+    def health(self, stat: DiagnosticStatusWrapper) -> DiagnosticStatusWrapper:
         """Function called by diagnostic updater to populate diagnostics status
         """
 
-        # TODO: fill diagnostic status message appropriately based on current system state
-        if self.system_status_ == DiagnosticStatus.ERROR:
-            stat.summary(DiagnosticStatus.ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.")
-            self.system_status_ = DiagnosticStatus.WARN
-        elif self.system_status_ == DiagnosticStatus.WARN:
-            stat.summary(DiagnosticStatus.WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.")
-            self.system_status_ = DiagnosticStatus.OK
-        elif self.system_status_ == DiagnosticStatus.OK:
-            stat.summary(DiagnosticStatus.OK, "Node is able to assess its own performance level and is reaching its desired performance level.")
-            self.system_status_ = DiagnosticStatus.STALE
+        # TODO: Remove this demonstration of health status and implement real health checks using `setHealth()`
+        if self.health_.status == DiagnosticStatus.ERROR:
+            self.setHealth(DiagnosticStatus.ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.", {"uptime": f"{self.get_clock().now().nanoseconds / 1e9}"})
+            self.health_.status = DiagnosticStatus.WARN
+        elif self.health_.status == DiagnosticStatus.WARN:
+            self.setHealth(DiagnosticStatus.WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.")
+            self.health_.status = DiagnosticStatus.OK
+        elif self.health_.status == DiagnosticStatus.OK:
+            self.setHealth(DiagnosticStatus.OK, "Node is able to assess its own performance level and is reaching its desired performance level.")
+            self.health_.status = DiagnosticStatus.STALE
         else:
-            stat.summary(DiagnosticStatus.STALE, "Node performance level cannot be assessed")
-            self.system_status_ = DiagnosticStatus.ERROR
-        # optional: add custom key-value pairs to diagnostics status
-        stat.add("Dummy Status Key", "Dummy Status Value")
+            self.setHealth(DiagnosticStatus.STALE, "Node performance level cannot be assessed")
+            self.health_.status = DiagnosticStatus.ERROR
+        # end of demonstration
 
+        stat.summary(self.health_.status, self.health_.msg)
+        if self.health_.key_value_pairs is not None:
+            for key, value in self.health_.key_value_pairs.items():
+                stat.add(key, value)
         return stat
+
+    def setHealth(self, status: DiagnosticStatus, msg: str, key_value_pairs: Optional[dict[str, str]] = None):
+        """Sets the health information published by diagnostic updater
+
+        Args:
+            status (DiagnosticStatus): system status
+            msg (str): status message
+            key_value_pairs (dict[str, str], optional): additional key-value pairs
+        """
+
+        self.health_ = Health(status, msg, key_value_pairs)
 
 
 def main():

--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -1,6 +1,7 @@
 import time
 from typing import Any, Optional, Union
 
+from dataclasses import dataclass
 from diagnostic_msgs.msg import DiagnosticStatus
 from diagnostic_updater import Updater
 from diagnostic_updater import TopicDiagnostic, FrequencyStatusParam, TimeStampStatusParam, DiagnosticStatusWrapper
@@ -15,18 +16,18 @@ from std_srvs.srv import SetBool
 from ros2_python_all_pkg_interfaces.action import Fibonacci
 
 
+@dataclass
 class TopicDiagnosticConfig:
-    def __init__(self, min_frequency: float, max_frequency: float, min_acceptable_timestamp_delta: float, max_acceptable_timestamp_delta: float):
-        self.min_frequency = min_frequency
-        self.max_frequency = max_frequency
-        self.min_acceptable_timestamp_delta = min_acceptable_timestamp_delta
-        self.max_acceptable_timestamp_delta = max_acceptable_timestamp_delta
+    min_frequency: float
+    max_frequency: float
+    min_acceptable_timestamp_delta: float
+    max_acceptable_timestamp_delta: float
 
+@dataclass
 class Health:
-    def __init__(self, status: DiagnosticStatus, msg: str, key_value_pairs: Optional[dict[str, str]] = None):
-        self.status = status
-        self.msg = msg
-        self.key_value_pairs = key_value_pairs
+    status: DiagnosticStatus
+    msg: str
+    key_value_pairs: Optional[dict[str, str]] = None
 
 
 class Ros2PythonNode(Node):

--- a/samples/ros2_python_pkg/package.xml
+++ b/samples/ros2_python_pkg/package.xml
@@ -11,8 +11,8 @@
 
   <license>TODO</license>
 
+  <depend>geometry_msgs</depend>
   <depend>rclpy</depend>
-  <depend>std_msgs</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
+++ b/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
@@ -1,10 +1,10 @@
 from typing import Any, Optional, Union
 
+from geometry_msgs.msg import PointStamped
 import rclpy
 from rclpy.node import Node
 import rclpy.exceptions
 from rcl_interfaces.msg import (FloatingPointRange, IntegerRange, ParameterDescriptor, SetParametersResult)
-from std_msgs.msg import Int32
 
 
 class Ros2PythonNode(Node):
@@ -126,26 +126,27 @@ class Ros2PythonNode(Node):
         self.add_on_set_parameters_callback(self.parameters_callback)
 
         # subscriber for handling incoming messages
-        self.subscriber = self.create_subscription(Int32,
+        self.subscriber = self.create_subscription(PointStamped,
                                                    "~/input",
                                                    self.topic_callback,
                                                    qos_profile=10)
         self.get_logger().info(f"Subscribed to '{self.subscriber.topic_name}'")
 
         # publisher for publishing outgoing messages
-        self.publisher = self.create_publisher(Int32,
+        self.publisher = self.create_publisher(PointStamped,
                                                "~/output",
                                                qos_profile=10)
         self.get_logger().info(f"Publishing to '{self.publisher.topic_name}'")
 
-    def topic_callback(self, msg: Int32):
+    def topic_callback(self, msg: PointStamped):
         """Processes messages received by a subscriber
 
         Args:
-            msg (Int32): message
+            msg (PointStamped): message
         """
 
-        self.get_logger().info(f"Message received: '{msg.data}'")
+        self.get_logger().info(f"Message received with stamp: '{msg.header.stamp}'")
+        self.publisher.publish(msg)
 
 
 def main():

--- a/templates/ros2_cpp_pkg/{{ package_name }}/CMakeLists.txt.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/CMakeLists.txt.jinja
@@ -17,6 +17,9 @@ find_package(rclcpp_components REQUIRED)
 {% if is_lifecycle %}
 find_package(rclcpp_lifecycle REQUIRED)
 {% endif %}
+{% if has_diagnostics %}
+find_package(diagnostic_updater REQUIRED)
+{% endif %}
 find_package(std_msgs REQUIRED)
 {% if has_service_server %}
 find_package(std_srvs REQUIRED)
@@ -57,6 +60,9 @@ target_link_libraries(${TARGET_NAME} PUBLIC
 {% endif %}
 {% if is_lifecycle %}
   ${rclcpp_lifecycle_TARGETS}
+{% endif %}
+{% if has_diagnostics %}
+  ${diagnostic_updater_TARGETS}
 {% endif %}
   ${std_msgs_TARGETS}
 {% if has_service_server %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/CMakeLists.txt.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/CMakeLists.txt.jinja
@@ -6,6 +6,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+{% if has_diagnostics %}
+find_package(diagnostic_updater REQUIRED)
+{% endif %}
 find_package(rclcpp REQUIRED)
 {% if has_action_server %}
 find_package(rclcpp_action REQUIRED)
@@ -16,9 +19,6 @@ find_package(rclcpp_components REQUIRED)
 {% endif %}
 {% if is_lifecycle %}
 find_package(rclcpp_lifecycle REQUIRED)
-{% endif %}
-{% if has_diagnostics %}
-find_package(diagnostic_updater REQUIRED)
 {% endif %}
 find_package(std_msgs REQUIRED)
 {% if has_service_server %}
@@ -51,6 +51,9 @@ target_compile_features(${TARGET_NAME} PUBLIC c_std_99 cxx_std_17)
 
 target_link_libraries(${TARGET_NAME} PUBLIC
   rclcpp::rclcpp
+{% if has_diagnostics %}
+  ${diagnostic_updater_TARGETS}
+{% endif %}
 {% if has_action_server %}
   ${rclcpp_action_TARGETS}
   {{ '${' ~ package_name ~ '_interfaces_TARGETS}' }}
@@ -60,9 +63,6 @@ target_link_libraries(${TARGET_NAME} PUBLIC
 {% endif %}
 {% if is_lifecycle %}
   ${rclcpp_lifecycle_TARGETS}
-{% endif %}
-{% if has_diagnostics %}
-  ${diagnostic_updater_TARGETS}
 {% endif %}
   ${std_msgs_TARGETS}
 {% if has_service_server %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/CMakeLists.txt.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/CMakeLists.txt.jinja
@@ -9,6 +9,9 @@ find_package(ament_cmake REQUIRED)
 {% if has_diagnostics %}
 find_package(diagnostic_updater REQUIRED)
 {% endif %}
+{% if has_subscriber or has_publisher %}
+find_package(geometry_msgs REQUIRED)
+{% endif %}
 find_package(rclcpp REQUIRED)
 {% if has_action_server %}
 find_package(rclcpp_action REQUIRED)
@@ -20,7 +23,6 @@ find_package(rclcpp_components REQUIRED)
 {% if is_lifecycle %}
 find_package(rclcpp_lifecycle REQUIRED)
 {% endif %}
-find_package(std_msgs REQUIRED)
 {% if has_service_server %}
 find_package(std_srvs REQUIRED)
 {% endif %}
@@ -54,6 +56,9 @@ target_link_libraries(${TARGET_NAME} PUBLIC
 {% if has_diagnostics %}
   ${diagnostic_updater_TARGETS}
 {% endif %}
+{% if has_subscriber or has_publisher %}
+  ${geometry_msgs_TARGETS}
+{% endif %}
 {% if has_action_server %}
   ${rclcpp_action_TARGETS}
   {{ '${' ~ package_name ~ '_interfaces_TARGETS}' }}
@@ -64,7 +69,6 @@ target_link_libraries(${TARGET_NAME} PUBLIC
 {% if is_lifecycle %}
   ${rclcpp_lifecycle_TARGETS}
 {% endif %}
-  ${std_msgs_TARGETS}
 {% if has_service_server %}
   ${std_srvs_TARGETS}
 {% endif %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -294,12 +294,13 @@ class {{ node_class_name }} : public rclcpp::Node {
   diagnostic_updater::Updater diagnostic_updater_{this};
   unsigned char system_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
 {% if has_subscriber %}
-  std::vector<std::shared_ptr<diagnostic_updater::DiagnosticTask>> diagnostic_tasks_;
-  std::unique_ptr<diagnostic_updater::TopicDiagnostic> topic_diagnostic_;
-  double min_freq_ = 0.5;
-  double max_freq_ = 5.0;
-  double min_delta_stamp_ = -0.1;
-  double max_delta_stamp_ = 0.1;
+  std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> subscriber_diagnostic_;
+  struct {
+    double freq_min = 0.5;
+    double freq_max = 5.0;
+    double freq_tolerance = 0.1;
+    int freq_window_size = 5;
+  } subscriber_diagnostic_params_;
 {% endif %}
 
   /**

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -41,6 +41,34 @@ template <typename C> struct is_vector : std::false_type {};
 template <typename T,typename A> struct is_vector< std::vector<T,A> > : std::true_type {};
 template <typename C> inline constexpr bool is_vector_v = is_vector<C>::value;
 {% endif %}
+{% if has_diagnostics %}
+
+
+/**
+ * @brief Configuration parameters for topic diagnostics
+ */
+struct TopicDiagnosticConfig {
+  /**
+   * @brief Minimum acceptable frequency
+   */
+  double min_frequency;
+  
+  /**
+   * @brief Maximum acceptable frequency
+   */
+  double max_frequency;
+  
+  /**
+   * @brief Minimum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  double min_acceptable_timestamp_delta;
+
+  /**
+   * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  double max_acceptable_timestamp_delta;
+};
+{% endif %}
 
 
 /**
@@ -312,40 +340,11 @@ class {{ node_class_name }} : public rclcpp::Node {
    * @brief Topic diagnostic to auto-diagnose a subscribed topic
    */
   std::unique_ptr<diagnostic_updater::TopicDiagnostic> topic_diagnostic_;
-  
-  /**
-   * @brief Minimum acceptable frequency of auto-diagnosed topic subscription
-   */
-  double topic_diagnostic_min_frequency_ = 1.0;
-  
-  /**
-   * @brief Maximum acceptable frequency of auto-diagnosed topic subscription
-   */
-  double topic_diagnostic_max_frequency_ = 1.0;
-  
-  /**
-   * @brief Tolerance for frequency deviation.
-   * Acceptable frequencies are from `min_frequency * (1 - frequency_tolerance)`
-   * to `max_frequency * (1 + frequency_tolerance)`.
-   */
-  const double topic_diagnostic_frequency_tolerance_ = 0.1;
-  
-  /**
-   * @brief Number of diagnostic calls to consider in the frequency calculation.
-   * It should be large enough to get a reliable estimate of the frequency depending
-   * on the expected message rate in relation to the diagnostic updater period.
-   */
-  const int topic_diagnostic_frequency_window_size_ = 5;
 
   /**
-   * @brief Minimum acceptable difference between message timestamp and receipt time (in seconds)
+   * @brief Configuration for auto-diagnosed topic subscription
    */
-  const double topic_diagnostic_min_acceptable_stamp_delta_ = -1.0;
-
-  /**
-   * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
-   */
-  const double topic_diagnostic_max_acceptable_stamp_delta_ = 5.0;  
+  TopicDiagnosticConfig topic_diagnostic_config_;
 {% endif %}
 {% if has_publisher %}
 
@@ -355,38 +354,9 @@ class {{ node_class_name }} : public rclcpp::Node {
   std::unique_ptr<diagnostic_updater::DiagnosedPublisher<geometry_msgs::msg::PointStamped>> diagnosed_publisher_;
 
   /**
-   * @brief Minimum acceptable frequency of auto-diagnosed publisher
+   * @brief Configuration for auto-diagnosed publisher
    */
-  double diagnosed_publisher_min_frequency_ = 1.0;
-  
-  /**
-   * @brief Maximum acceptable frequency of auto-diagnosed publisher
-   */
-  double diagnosed_publisher_max_frequency_ = 1.0;
-  
-  /**
-   * @brief Tolerance for frequency deviation.
-   * Acceptable frequencies are from `min_frequency * (1 - frequency_tolerance)`
-   * to `max_frequency * (1 + frequency_tolerance)`.
-   */
-  const double diagnosed_publisher_frequency_tolerance_ = 0.1;
-  
-  /**
-   * @brief Number of diagnostic calls to consider in the frequency calculation.
-   * It should be large enough to get a reliable estimate of the frequency depending
-   * on the expected message rate in relation to the diagnostic updater period.
-   */
-  const int diagnosed_publisher_frequency_window_size_ = 5;
-
-  /**
-   * @brief Minimum acceptable difference between message timestamp and receipt time (in seconds)
-   */
-  const double diagnosed_publisher_min_acceptable_stamp_delta_ = -1.0;
-
-  /**
-   * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
-   */
-  const double diagnosed_publisher_max_acceptable_stamp_delta_ = 5.0;  
+  TopicDiagnosticConfig diagnosed_publisher_config_;  
 {% endif %}
 {% endif %}
 {% if auto_shutdown %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -307,6 +307,7 @@ class {{ node_class_name }} : public rclcpp::Node {
    */
   unsigned char health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
 {% if has_subscriber %}
+
   /**
    * @brief Topic diagnostic to auto-diagnose a subscribed topic
    */
@@ -345,6 +346,47 @@ class {{ node_class_name }} : public rclcpp::Node {
    * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
    */
   const double topic_diagnostic_max_acceptable_stamp_delta_ = 5.0;  
+{% endif %}
+{% if has_publisher %}
+
+  /**
+   * @brief Diagnosed publisher
+   */
+  std::unique_ptr<diagnostic_updater::DiagnosedPublisher<geometry_msgs::msg::PointStamped>> diagnosed_publisher_;
+
+  /**
+   * @brief Minimum acceptable frequency of auto-diagnosed publisher
+   */
+  double diagnosed_publisher_min_frequency_ = 1.0;
+  
+  /**
+   * @brief Maximum acceptable frequency of auto-diagnosed publisher
+   */
+  double diagnosed_publisher_max_frequency_ = 1.0;
+  
+  /**
+   * @brief Tolerance for frequency deviation.
+   * Acceptable frequencies are from `min_frequency * (1 - frequency_tolerance)`
+   * to `max_frequency * (1 + frequency_tolerance)`.
+   */
+  const double diagnosed_publisher_frequency_tolerance_ = 0.1;
+  
+  /**
+   * @brief Number of diagnostic calls to consider in the frequency calculation.
+   * It should be large enough to get a reliable estimate of the frequency depending
+   * on the expected message rate in relation to the diagnostic updater period.
+   */
+  const int diagnosed_publisher_frequency_window_size_ = 5;
+
+  /**
+   * @brief Minimum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  const double diagnosed_publisher_min_acceptable_stamp_delta_ = -1.0;
+
+  /**
+   * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  const double diagnosed_publisher_max_acceptable_stamp_delta_ = 5.0;  
 {% endif %}
 {% endif %}
 {% if auto_shutdown %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -22,7 +22,9 @@
 {% endif %}
 {% if has_diagnostics %}
 #include <diagnostic_updater/diagnostic_updater.hpp>
+{% if has_subscriber %}
 #include <diagnostic_updater/publisher.hpp>
+{% endif %}
 {% endif %}
 {% if has_action_server %}
 

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -310,7 +310,7 @@ class {{ node_class_name }} : public rclcpp::Node {
   /**
    * @brief Topic diagnostic to auto-diagnose a subscribed topic
    */
-  std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> topic_diagnostic_;
+  std::unique_ptr<diagnostic_updater::TopicDiagnostic> topic_diagnostic_;
   
   /**
    * @brief Minimum acceptable frequency of auto-diagnosed topic subscription
@@ -335,7 +335,16 @@ class {{ node_class_name }} : public rclcpp::Node {
    * on the expected message rate in relation to the diagnostic updater period.
    */
   const int topic_diagnostic_frequency_window_size_ = 5;
-  
+
+  /**
+   * @brief Minimum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  const double topic_diagnostic_min_acceptable_stamp_delta_ = -1.0;
+
+  /**
+   * @brief Maximum acceptable difference between message timestamp and receipt time (in seconds)
+   */
+  const double topic_diagnostic_max_acceptable_stamp_delta_ = 5.0;  
 {% endif %}
 {% endif %}
 {% if auto_shutdown %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -217,6 +217,13 @@ class {{ node_class_name }} : public rclcpp::Node {
    */
   void timerCallback();
 {% endif %}
+{% if has_diagnostics %}
+
+  /**
+   * @brief Function called by diagnostic updater to populate diagnostics status
+   */
+  void health(diagnostic_updater::DiagnosticStatusWrapper &stat);
+{% endif %}
 {% if auto_shutdown %}
 
   /**
@@ -302,11 +309,6 @@ class {{ node_class_name }} : public rclcpp::Node {
     int freq_window_size = 5;
   } subscriber_diagnostic_params_;
 {% endif %}
-
-  /**
-   * @brief Function called by diagnostic updater to populate diagnostics status
-   */
-  void health(diagnostic_updater::DiagnosticStatusWrapper &stat);
 {% endif %}
 {% if auto_shutdown %}
 

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -20,6 +20,9 @@
 {% if has_service_server %}
 #include <std_srvs/srv/set_bool.hpp>
 {% endif %}
+{% if has_diagnostics %}
+#include <diagnostic_updater/diagnostic_updater.hpp>
+{% endif %}
 {% if has_action_server %}
 
 #include <{{ package_name }}_interfaces/action/fibonacci.hpp>
@@ -279,6 +282,18 @@ class {{ node_class_name }} : public rclcpp::Node {
    * @brief Dummy parameter (parameter)
    */
   double param_ = 1.0;
+{% endif %}
+{% if has_diagnostics %}
+
+  /**
+   * @brief Diagnostic updater publishes to "/diagnostics" with period set in parameter "~diagnostic_updater.period"
+   */
+  diagnostic_updater::Updater diagnostic_updater_{this};
+
+  /**
+   * @brief Function called by diagnostic updater to populate diagnostics status
+   */
+  void diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);
 {% endif %}
 {% if auto_shutdown %}
 

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -4,6 +4,12 @@
 #include <string>
 #include <vector>
 
+{% if has_diagnostics %}
+#include <diagnostic_updater/diagnostic_updater.hpp>
+{% if has_subscriber %}
+#include <diagnostic_updater/publisher.hpp>
+{% endif %}
+{% endif %}
 {% if is_lifecycle %}
 #include <lifecycle_msgs/msg/state.hpp>
 #include <lifecycle_msgs/msg/transition.hpp>
@@ -19,12 +25,6 @@
 #include <std_msgs/msg/int32.hpp>
 {% if has_service_server %}
 #include <std_srvs/srv/set_bool.hpp>
-{% endif %}
-{% if has_diagnostics %}
-#include <diagnostic_updater/diagnostic_updater.hpp>
-{% if has_subscriber %}
-#include <diagnostic_updater/publisher.hpp>
-{% endif %}
 {% endif %}
 {% if has_action_server %}
 

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -255,7 +255,7 @@ class {{ node_class_name }} : public rclcpp::Node {
   void health(diagnostic_updater::DiagnosticStatusWrapper &stat);
 
   /**
-   * @brief Sets the health information published by diagnostic updater
+   * @brief Sets the health information and triggers publishing by diagnostic updater
    */
   void setHealth(const unsigned char status, const std::string& msg, const std::map<std::string, std::string>& key_value_pairs = {});
 {% endif %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -253,6 +253,11 @@ class {{ node_class_name }} : public rclcpp::Node {
    * @brief Function called by diagnostic updater to populate diagnostics status
    */
   void health(diagnostic_updater::DiagnosticStatusWrapper &stat);
+
+  /**
+   * @brief Sets the health information published by diagnostic updater
+   */
+  void setHealth(const unsigned char status, const std::string& msg, const std::map<std::string, std::string>& key_value_pairs = {});
 {% endif %}
 {% if auto_shutdown %}
 
@@ -333,7 +338,11 @@ class {{ node_class_name }} : public rclcpp::Node {
    /**
    * @brief Diagnostic status indicating node health
    */
-  unsigned char health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+  struct DiagnosticStatus {
+    unsigned char status = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+    std::string message = "";
+    std::map<std::string, std::string> key_value_pairs = {};
+  } health_;
 {% if has_subscriber %}
 
   /**

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -306,19 +306,34 @@ class {{ node_class_name }} : public rclcpp::Node {
   unsigned char health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
 {% if has_subscriber %}
   /**
-   * @brief Topic diagnostic to diagnose a subscribed topic
+   * @brief Topic diagnostic to auto-diagnose a subscribed topic
    */
-  std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> subscriber_diagnostic_;
+  std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> topic_diagnostic_;
   
   /**
-   * @brief Parameters for configuring subscriber diagnostic monitoring
+   * @brief Minimum acceptable frequency of auto-diagnosed topic subscription
    */
-  struct {
-    double min_frequency = 0.5;           ///< Minimum expected message frequency (Hz)
-    double max_frequency = 5.0;           ///< Maximum expected message frequency (Hz)
-    double frequency_tolerance = 0.1;     ///< Tolerance for frequency deviation. Acceptable values are from 'min_frequency*(1-frequency_tolerance)' to 'max_frequency*(1+frequency_tolerance)'.
-    int frequency_window_size = 5;        ///< Number of diagnostic calls (depending on 'diagnostic_updater.period' parameter) to consider in the frequency calculation. It should be large enough to get a reliable estimate of the frequency depending on the expected message rate in relation to the diagnostic updater period.
-  } subscriber_diagnostic_params_;
+  double topic_diagnostic_min_frequency_ = 1.0;
+  
+  /**
+   * @brief Maximum acceptable frequency of auto-diagnosed topic subscription
+   */
+  double topic_diagnostic_max_frequency_ = 1.0;
+  
+  /**
+   * @brief Tolerance for frequency deviation.
+   * Acceptable frequencies are from `min_frequency * (1 - frequency_tolerance)`
+   * to `max_frequency * (1 + frequency_tolerance)`.
+   */
+  const double topic_diagnostic_frequency_tolerance_ = 0.1;
+  
+  /**
+   * @brief Number of diagnostic calls to consider in the frequency calculation.
+   * It should be large enough to get a reliable estimate of the frequency depending
+   * on the expected message rate in relation to the diagnostic updater period.
+   */
+  const int topic_diagnostic_frequency_window_size_ = 5;
+  
 {% endif %}
 {% endif %}
 {% if auto_shutdown %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -292,6 +292,7 @@ class {{ node_class_name }} : public rclcpp::Node {
    * @brief Diagnostic updater publishes to "/diagnostics" with period set in parameter "~diagnostic_updater.period"
    */
   diagnostic_updater::Updater diagnostic_updater_{this};
+  unsigned char system_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
 {% if has_subscriber %}
   std::vector<std::shared_ptr<diagnostic_updater::DiagnosticTask>> diagnostic_tasks_;
   std::unique_ptr<diagnostic_updater::TopicDiagnostic> topic_diagnostic_;

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -36,7 +36,7 @@
 
 namespace {{ package_name }} {
 
-{% if has_params or is_lifecycle %}
+{% if has_params or is_lifecycle or has_diagnostics %}
 template <typename C> struct is_vector : std::false_type {};
 template <typename T,typename A> struct is_vector< std::vector<T,A> > : std::true_type {};
 template <typename C> inline constexpr bool is_vector_v = is_vector<C>::value;
@@ -145,7 +145,7 @@ class {{ node_class_name }} : public rclcpp::Node {
 {% endif %}
 
  private:
-{% if has_params or is_lifecycle %}
+{% if has_params or is_lifecycle or has_diagnostics %}
 
   /**
    * @brief Declares and loads a ROS parameter
@@ -268,7 +268,7 @@ class {{ node_class_name }} : public rclcpp::Node {
 {% endif %}
 
  private:
-{% if has_params or is_lifecycle %}
+{% if has_params or is_lifecycle or has_diagnostics %}
 
   /**
    * @brief Auto-reconfigurable parameters for dynamic reconfiguration

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -10,6 +10,9 @@
 #include <diagnostic_updater/publisher.hpp>
 {% endif %}
 {% endif %}
+{% if has_subscriber or has_publisher %}
+#include <geometry_msgs/msg/point_stamped.hpp>
+{% endif %}
 {% if is_lifecycle %}
 #include <lifecycle_msgs/msg/state.hpp>
 #include <lifecycle_msgs/msg/transition.hpp>
@@ -22,7 +25,6 @@
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <rclcpp_lifecycle/lifecycle_publisher.hpp>
 {% endif %}
-#include <std_msgs/msg/int32.hpp>
 {% if has_service_server %}
 #include <std_srvs/srv/set_bool.hpp>
 {% endif %}
@@ -165,7 +167,7 @@ class {{ node_class_name }} : public rclcpp::Node {
    *
    * @param msg message
    */
-  void topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg);
+  void topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg);
 {% endif %}
 {% if has_service_server %}
 
@@ -252,7 +254,7 @@ class {{ node_class_name }} : public rclcpp::Node {
   /**
    * @brief Subscriber
    */
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr subscriber_;
+  rclcpp::Subscription<geometry_msgs::msg::PointStamped>::SharedPtr subscriber_;
 {% endif %}
 {% if has_publisher %}
 
@@ -260,9 +262,9 @@ class {{ node_class_name }} : public rclcpp::Node {
    * @brief Publisher
    */
 {% if is_lifecycle %}
-  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Int32>::SharedPtr publisher_;
+  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PointStamped>::SharedPtr publisher_;
 {% else %}
-  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr publisher_;
+  rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr publisher_;
 {% endif %}
 {% endif %}
 {% if has_service_server %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -6,7 +6,7 @@
 
 {% if has_diagnostics %}
 #include <diagnostic_updater/diagnostic_updater.hpp>
-{% if has_subscriber %}
+{% if has_subscriber or has_publisher %}
 #include <diagnostic_updater/publisher.hpp>
 {% endif %}
 {% endif %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -306,7 +306,7 @@ class {{ node_class_name }} : public rclcpp::Node {
   /**
    * @brief Function called by diagnostic updater to populate diagnostics status
    */
-  void diagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);
+  void health(diagnostic_updater::DiagnosticStatusWrapper &stat);
 {% endif %}
 {% if auto_shutdown %}
 

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -22,6 +22,7 @@
 {% endif %}
 {% if has_diagnostics %}
 #include <diagnostic_updater/diagnostic_updater.hpp>
+#include <diagnostic_updater/publisher.hpp>
 {% endif %}
 {% if has_action_server %}
 
@@ -289,6 +290,14 @@ class {{ node_class_name }} : public rclcpp::Node {
    * @brief Diagnostic updater publishes to "/diagnostics" with period set in parameter "~diagnostic_updater.period"
    */
   diagnostic_updater::Updater diagnostic_updater_{this};
+{% if has_subscriber %}
+  std::vector<std::shared_ptr<diagnostic_updater::DiagnosticTask>> diagnostic_tasks_;
+  std::unique_ptr<diagnostic_updater::TopicDiagnostic> topic_diagnostic_;
+  double min_freq_ = 0.5;
+  double max_freq_ = 5.0;
+  double min_delta_stamp_ = -0.1;
+  double max_delta_stamp_ = 0.1;
+{% endif %}
 
   /**
    * @brief Function called by diagnostic updater to populate diagnostics status

--- a/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/include/{{ package_name }}/{{ node_name }}.hpp.jinja
@@ -296,17 +296,28 @@ class {{ node_class_name }} : public rclcpp::Node {
 {% if has_diagnostics %}
 
   /**
-   * @brief Diagnostic updater publishes to "/diagnostics" with period set in parameter "~diagnostic_updater.period"
+   * @brief Diagnostic updater
    */
   diagnostic_updater::Updater diagnostic_updater_{this};
-  unsigned char system_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+  
+   /**
+   * @brief Diagnostic status indicating node health
+   */
+  unsigned char health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
 {% if has_subscriber %}
+  /**
+   * @brief Topic diagnostic to diagnose a subscribed topic
+   */
   std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> subscriber_diagnostic_;
+  
+  /**
+   * @brief Parameters for configuring subscriber diagnostic monitoring
+   */
   struct {
-    double freq_min = 0.5;
-    double freq_max = 5.0;
-    double freq_tolerance = 0.1;
-    int freq_window_size = 5;
+    double min_frequency = 0.5;           ///< Minimum expected message frequency (Hz)
+    double max_frequency = 5.0;           ///< Maximum expected message frequency (Hz)
+    double frequency_tolerance = 0.1;     ///< Tolerance for frequency deviation. Acceptable values are from 'min_frequency*(1-frequency_tolerance)' to 'max_frequency*(1+frequency_tolerance)'.
+    int frequency_window_size = 5;        ///< Number of diagnostic calls (depending on 'diagnostic_updater.period' parameter) to consider in the frequency calculation. It should be large enough to get a reliable estimate of the frequency depending on the expected message rate in relation to the diagnostic updater period.
   } subscriber_diagnostic_params_;
 {% endif %}
 {% endif %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/package.xml.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/package.xml.jinja
@@ -16,6 +16,9 @@
 {% if has_diagnostics %}
   <depend>diagnostic_updater</depend>
 {% endif %}
+{% if has_subscriber or has_publisher %}
+  <depend>geometry_msgs</depend>
+{% endif %}
   <depend>rclcpp</depend>
 {% if has_action_server %}
   <depend>rclcpp_action</depend>
@@ -26,7 +29,6 @@
 {% if is_lifecycle %}
   <depend>rclcpp_lifecycle</depend>
 {% endif %}
-  <depend>std_msgs</depend>
 {% if has_service_server %}
   <depend>std_srvs</depend>
 {% endif %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/package.xml.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/package.xml.jinja
@@ -13,6 +13,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+{% if has_diagnostics %}
+  <depend>diagnostic_updater</depend>
+{% endif %}
   <depend>rclcpp</depend>
 {% if has_action_server %}
   <depend>rclcpp_action</depend>

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -221,6 +221,9 @@ void {{ node_class_name }}::setup() {
 
 void {{ node_class_name }}::topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg) {
 
+{% if has_diagnostics %}
+  subscriber_diagnostic_->tick();
+{% endif %}
   RCLCPP_INFO(this->get_logger(), "Message received: '%d'", msg->data);
 
 {% if has_publisher %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -202,7 +202,7 @@ void {{ node_class_name }}::setup() {
 
   // setup diagnostic updater
   diagnostic_updater_.setHardwareID(this->get_name());
-  diagnostic_updater_.add("{{ node_name }} diagnostics", this, &{{ node_class_name }}::diagnostics);
+  diagnostic_updater_.add("{{ node_name }} Status", this, &{{ node_class_name }}::diagnostics);
   // optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
 {% endif %}
 {% if auto_shutdown and not is_lifecycle %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -204,10 +204,11 @@ void {{ node_class_name }}::setup() {
   diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("Health", this, &{{ node_class_name }}::health);
 {% if has_subscriber %}
-  topic_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
+  topic_diagnostic_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_min_frequency_, &topic_diagnostic_max_frequency_, topic_diagnostic_frequency_tolerance_, topic_diagnostic_frequency_window_size_)
+    diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_min_frequency_, &topic_diagnostic_max_frequency_, topic_diagnostic_frequency_tolerance_, topic_diagnostic_frequency_window_size_),
+    diagnostic_updater::TimeStampStatusParam(topic_diagnostic_min_acceptable_stamp_delta_, topic_diagnostic_max_acceptable_stamp_delta_)
   );
 {% endif %}
 {% endif %}
@@ -222,7 +223,7 @@ void {{ node_class_name }}::setup() {
 void {{ node_class_name }}::topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg) {
 
 {% if has_diagnostics %}
-  topic_diagnostic_->tick();
+  topic_diagnostic_->tick(msg->header.stamp);
 {% endif %}
   RCLCPP_INFO(this->get_logger(), "Message received with stamp: '%d'", msg->header.stamp.sec);
 

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -345,7 +345,19 @@ void {{ node_class_name }}::timerCallback() {
 void {{ node_class_name }}::diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
   // TODO: fill diagnostic status message appropriately based on current system state
-  stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is running properly");
+  if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.");
+    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+  } else if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.");
+    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  } else if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::OK) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is able to assess its own performance level and is reaching its desired performance level.");
+    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+  } else {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "Node performance level cannot be assessed");
+    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+  }
   // optional: add custom key-value pairs to diagnostics status
   stat.add("Dummy Status Key", "Dummy Status Value");
 }

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -201,7 +201,7 @@ void {{ node_class_name }}::setup() {
 {% if has_diagnostics %}
 
   // setup diagnostic updater
-  diagnostic_updater_.setHardwareID(this->get_name());
+  diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("{{ node_name }} Status", this, &{{ node_class_name }}::diagnostics);
   // optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
 {% if has_subscriber %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -375,12 +375,7 @@ void {{ node_class_name }}::actionExecute(const std::shared_ptr<rclcpp_action::S
 void {{ node_class_name }}::timerCallback() {
 
   RCLCPP_INFO(this->get_logger(), "Timer triggered");
-}
-{% endif %}
 {% if has_diagnostics %}
-
-
-void {{ node_class_name }}::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
   // TODO: Remove this demonstration of health status and implement real health checks using `setHealth()`
   if(health_.status == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
@@ -397,6 +392,13 @@ void {{ node_class_name }}::health(diagnostic_updater::DiagnosticStatusWrapper& 
     health_.status = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
   }
   // end of demonstration
+{% endif %}
+}
+{% endif %}
+{% if has_diagnostics %}
+
+
+void {{ node_class_name }}::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
   stat.summary(health_.status, health_.message);
   for (const auto& [key, value] : health_.key_value_pairs) {
@@ -406,9 +408,11 @@ void {{ node_class_name }}::health(diagnostic_updater::DiagnosticStatusWrapper& 
 
 
 void {{ node_class_name }}::setHealth(const unsigned char status, const std::string& msg, const std::map<std::string, std::string>& key_value_pairs) {
+
   health_.status = status;
   health_.message = msg;
   health_.key_value_pairs = key_value_pairs;
+  diagnostic_updater_.force_update();
 }
 {% endif %}
 {% if auto_shutdown %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -418,16 +418,16 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn {{ nod
 {% endif %}
 {% if has_diagnostics %}
 {% if has_subscriber %}
-  this->declareAndLoadParameter("topic_diagnostic.min_frequency", topic_diagnostic_config_.min_frequency, "Minimum frequency for incoming messages", true, true, false);
-  this->declareAndLoadParameter("topic_diagnostic.max_frequency", topic_diagnostic_config_.max_frequency, "Maximum frequency for incoming messages", true, true, false);
-  this->declareAndLoadParameter("topic_diagnostic.min_acceptable_timestamp_delta", topic_diagnostic_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for incoming messages", true, true, false);
-  this->declareAndLoadParameter("topic_diagnostic.max_acceptable_timestamp_delta", topic_diagnostic_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.min_frequency", topic_diagnostic_config_.min_frequency, "Minimum frequency for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.max_frequency", topic_diagnostic_config_.max_frequency, "Maximum frequency for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.min_acceptable_timestamp_delta", topic_diagnostic_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.max_acceptable_timestamp_delta", topic_diagnostic_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for incoming messages", true, true, false);
 {% endif %}
 {% if has_publisher %}
-  this->declareAndLoadParameter("diagnosed_publisher.min_frequency", diagnosed_publisher_config_.min_frequency, "Minimum frequency for outgoing messages", true, true, false);
-  this->declareAndLoadParameter("diagnosed_publisher.max_frequency", diagnosed_publisher_config_.max_frequency, "Maximum frequency for outgoing messages", true, true, false);
-  this->declareAndLoadParameter("diagnosed_publisher.min_acceptable_timestamp_delta", diagnosed_publisher_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for outgoing messages", true, true, false);
-  this->declareAndLoadParameter("diagnosed_publisher.max_acceptable_timestamp_delta", diagnosed_publisher_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.min_frequency", diagnosed_publisher_config_.min_frequency, "Minimum frequency for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.max_frequency", diagnosed_publisher_config_.max_frequency, "Maximum frequency for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.min_acceptable_timestamp_delta", diagnosed_publisher_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.max_acceptable_timestamp_delta", diagnosed_publisher_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for outgoing messages", true, true, false);
 {% endif %}
 {% endif %}
   setup();

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -165,16 +165,16 @@ void {{ node_class_name }}::setup() {
 
   // subscriber for handling incoming messages
 {% if executor_type == "MultiThreadedExecutor" %}
-  subscriber_ = this->create_subscription<std_msgs::msg::Int32>("~/input", 10, std::bind(&{{ node_class_name }}::topicCallback, this, std::placeholders::_1), subscriber_options);
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&{{ node_class_name }}::topicCallback, this, std::placeholders::_1), subscriber_options);
 {% else %}
-  subscriber_ = this->create_subscription<std_msgs::msg::Int32>("~/input", 10, std::bind(&{{ node_class_name }}::topicCallback, this, std::placeholders::_1));
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&{{ node_class_name }}::topicCallback, this, std::placeholders::_1));
 {% endif %}
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 {% endif %}
 {% if has_publisher %}
 
   // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<std_msgs::msg::Int32>("~/output", 10);
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 {% endif %}
 {% if has_service_server %}
@@ -219,25 +219,25 @@ void {{ node_class_name }}::setup() {
 {% if has_subscriber %}
 
 
-void {{ node_class_name }}::topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg) {
+void {{ node_class_name }}::topicCallback(const geometry_msgs::msg::PointStamped::ConstSharedPtr& msg) {
 
 {% if has_diagnostics %}
   topic_diagnostic_->tick();
 {% endif %}
-  RCLCPP_INFO(this->get_logger(), "Message received: '%d'", msg->data);
+  RCLCPP_INFO(this->get_logger(), "Message received with stamp: '%d'", msg->header.stamp.sec);
 
 {% if has_publisher %}
   // publish message
   {% if is_component %}
-  std_msgs::msg::Int32::UniquePtr out_msg = std::make_unique<std_msgs::msg::Int32>();
-  out_msg->data = msg->data;
-  RCLCPP_INFO(this->get_logger(), "Message published: '%d'", out_msg->data);
+  geometry_msgs::msg::PointStamped::UniquePtr out_msg = std::make_unique<geometry_msgs::msg::PointStamped>();
+  *out_msg = *msg;
+  RCLCPP_INFO(this->get_logger(), "Message published with stamp: '%d'", out_msg->header.stamp.sec);
   publisher_->publish(std::move(out_msg));
   {% else %}
-  std_msgs::msg::Int32 out_msg;
-  out_msg.data = msg->data;
+  geometry_msgs::msg::PointStamped out_msg;
+  out_msg = *msg;
   publisher_->publish(out_msg);
-  RCLCPP_INFO(this->get_logger(), "Message published: '%d'", out_msg.data);
+  RCLCPP_INFO(this->get_logger(), "Message published with stamp: '%d'", out_msg.header.stamp.sec);
   {% endif %}
 {% endif %}
 }

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -61,7 +61,7 @@ namespace {{ package_name }} {
   this->setup();
 {% endif %}
 }
-{% if has_params or is_lifecycle %}
+{% if has_params or is_lifecycle or has_diagnostics %}
 
 
 template <typename T>

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -198,6 +198,13 @@ void {{ node_class_name }}::setup() {
   // timer for repeatedly invoking a callback
   timer_ = this->create_wall_timer(std::chrono::duration<double>(1.0), std::bind(&{{ node_class_name }}::timerCallback, this));
 {% endif %}
+{% if has_diagnostics %}
+
+  // setup diagnostic updater
+  diagnostic_updater_.setHardwareID(this->get_name());
+  diagnostic_updater_.add("{{ node_name }} diagnostics", this, &{{ node_class_name }}::diagnostics);
+  // optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
+{% endif %}
 {% if auto_shutdown and not is_lifecycle %}
 
   auto_shutdown_timer_ = this->create_wall_timer(std::chrono::duration<double>(3.0), std::bind(&{{ node_class_name }}::autoShutdownTimerCallback, this));
@@ -322,6 +329,17 @@ void {{ node_class_name }}::actionExecute(const std::shared_ptr<rclcpp_action::S
 void {{ node_class_name }}::timerCallback() {
 
   RCLCPP_INFO(this->get_logger(), "Timer triggered");
+}
+{% endif %}
+{% if has_diagnostics %}
+
+
+void {{ node_class_name }}::diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat) {
+
+  // TODO: fill diagnostic status message appropriately based on current system state
+  stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is running properly");
+  // optional: add custom key-value pairs to diagnostics status
+  stat.add("Dummy Status Key", "Dummy Status Value");
 }
 {% endif %}
 {% if auto_shutdown %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -203,7 +203,6 @@ void {{ node_class_name }}::setup() {
   // setup diagnostic updater
   diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("{{ node_name }} Status", this, &{{ node_class_name }}::diagnostics);
-  // optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
 {% if has_subscriber %}
   topic_diagnostic_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
     "~/input",

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -204,11 +204,10 @@ void {{ node_class_name }}::setup() {
   diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("{{ node_name }} Status", this, &{{ node_class_name }}::diagnostics);
 {% if has_subscriber %}
-  topic_diagnostic_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
+  subscriber_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&min_freq_, &max_freq_),
-    diagnostic_updater::TimeStampStatusParam(min_delta_stamp_, max_delta_stamp_)
+    diagnostic_updater::FrequencyStatusParam(&subscriber_diagnostic_params_.freq_min, &subscriber_diagnostic_params_.freq_max, subscriber_diagnostic_params_.freq_tolerance, subscriber_diagnostic_params_.freq_window_size)
   );
 {% endif %}
 {% endif %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -406,14 +406,18 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn {{ nod
   this->declareAndLoadParameter("param", param_, "TODO", true, false, false, 0.0, 10.0, 1.0);
 {% endif %}
 {% if has_diagnostics %}
+{% if has_subscriber %}
   this->declareAndLoadParameter("topic_diagnostic.min_frequency", topic_diagnostic_config_.min_frequency, "Minimum frequency for incoming messages", true, true, false);
   this->declareAndLoadParameter("topic_diagnostic.max_frequency", topic_diagnostic_config_.max_frequency, "Maximum frequency for incoming messages", true, true, false);
   this->declareAndLoadParameter("topic_diagnostic.min_acceptable_timestamp_delta", topic_diagnostic_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for incoming messages", true, true, false);
   this->declareAndLoadParameter("topic_diagnostic.max_acceptable_timestamp_delta", topic_diagnostic_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for incoming messages", true, true, false);
+{% endif %}
+{% if has_publisher %}
   this->declareAndLoadParameter("diagnosed_publisher.min_frequency", diagnosed_publisher_config_.min_frequency, "Minimum frequency for outgoing messages", true, true, false);
   this->declareAndLoadParameter("diagnosed_publisher.max_frequency", diagnosed_publisher_config_.max_frequency, "Maximum frequency for outgoing messages", true, true, false);
   this->declareAndLoadParameter("diagnosed_publisher.min_acceptable_timestamp_delta", diagnosed_publisher_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for outgoing messages", true, true, false);
   this->declareAndLoadParameter("diagnosed_publisher.max_acceptable_timestamp_delta", diagnosed_publisher_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for outgoing messages", true, true, false);
+{% endif %}
 {% endif %}
   setup();
 

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -204,6 +204,14 @@ void {{ node_class_name }}::setup() {
   diagnostic_updater_.setHardwareID(this->get_name());
   diagnostic_updater_.add("{{ node_name }} Status", this, &{{ node_class_name }}::diagnostics);
   // optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
+{% if has_subscriber %}
+  topic_diagnostic_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
+    "~/input",
+    diagnostic_updater_,
+    diagnostic_updater::FrequencyStatusParam(&min_freq_, &max_freq_),
+    diagnostic_updater::TimeStampStatusParam(min_delta_stamp_, max_delta_stamp_)
+  );
+{% endif %}
 {% endif %}
 {% if auto_shutdown and not is_lifecycle %}
 

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -211,6 +211,14 @@ void {{ node_class_name }}::setup() {
     diagnostic_updater::TimeStampStatusParam(topic_diagnostic_min_acceptable_stamp_delta_, topic_diagnostic_max_acceptable_stamp_delta_)
   );
 {% endif %}
+{% if has_publisher %}
+  diagnosed_publisher_ = std::make_unique<diagnostic_updater::DiagnosedPublisher<geometry_msgs::msg::PointStamped>>(
+    publisher_,
+    diagnostic_updater_,
+    diagnostic_updater::FrequencyStatusParam(&diagnosed_publisher_min_frequency_, &diagnosed_publisher_max_frequency_, diagnosed_publisher_frequency_tolerance_, diagnosed_publisher_frequency_window_size_),
+    diagnostic_updater::TimeStampStatusParam(diagnosed_publisher_min_acceptable_stamp_delta_, diagnosed_publisher_max_acceptable_stamp_delta_)
+  );
+{% endif %}
 {% endif %}
 {% if auto_shutdown and not is_lifecycle %}
 
@@ -233,11 +241,19 @@ void {{ node_class_name }}::topicCallback(const geometry_msgs::msg::PointStamped
   geometry_msgs::msg::PointStamped::UniquePtr out_msg = std::make_unique<geometry_msgs::msg::PointStamped>();
   *out_msg = *msg;
   RCLCPP_INFO(this->get_logger(), "Message published with stamp: '%d'", out_msg->header.stamp.sec);
+  {% if has_diagnostics %}
+  diagnosed_publisher_->publish(std::move(out_msg));
+  {% else %}
   publisher_->publish(std::move(out_msg));
+  {% endif %}
   {% else %}
   geometry_msgs::msg::PointStamped out_msg;
   out_msg = *msg;
+  {% if has_diagnostics %}
+  diagnosed_publisher_->publish(out_msg);
+  {% else %}
   publisher_->publish(out_msg);
+  {% endif %}
   RCLCPP_INFO(this->get_logger(), "Message published with stamp: '%d'", out_msg.header.stamp.sec);
   {% endif %}
 {% endif %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -202,7 +202,7 @@ void {{ node_class_name }}::setup() {
 
   // setup diagnostic updater
   diagnostic_updater_.setHardwareID("none");
-  diagnostic_updater_.add("{{ node_name }} Status", this, &{{ node_class_name }}::diagnostics);
+  diagnostic_updater_.add("Health", this, &{{ node_class_name }}::health);
 {% if has_subscriber %}
   subscriber_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
     "~/input",
@@ -343,7 +343,7 @@ void {{ node_class_name }}::timerCallback() {
 {% if has_diagnostics %}
 
 
-void {{ node_class_name }}::diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat) {
+void {{ node_class_name }}::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
   // TODO: fill diagnostic status message appropriately based on current system state
   if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -368,22 +368,33 @@ void {{ node_class_name }}::timerCallback() {
 
 void {{ node_class_name }}::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
-  // TODO: fill diagnostic status message appropriately based on current system state
-  if(health_ == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.");
-    health_ = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-  } else if(health_ == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.");
-    health_ = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  } else if(health_ == diagnostic_msgs::msg::DiagnosticStatus::OK) {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is able to assess its own performance level and is reaching its desired performance level.");
-    health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+  // TODO: Remove this demonstration of health status and implement real health checks using `setHealth()`
+  if(health_.status == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+    setHealth(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.", { {"uptime", std::to_string(this->get_clock()->now().seconds())} });
+    health_.status = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+  } else if(health_.status == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
+    setHealth(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.");
+    health_.status = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  } else if(health_.status == diagnostic_msgs::msg::DiagnosticStatus::OK) {
+    setHealth(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is able to assess its own performance level and is reaching its desired performance level.");
+    health_.status = diagnostic_msgs::msg::DiagnosticStatus::STALE;
   } else {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "Node performance level cannot be assessed");
-    health_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    setHealth(diagnostic_msgs::msg::DiagnosticStatus::STALE, "Node performance level cannot be assessed");
+    health_.status = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
   }
-  // optional: add custom key-value pairs to diagnostics status
-  stat.add("Dummy Status Key", "Dummy Status Value");
+  // end of demonstration
+
+  stat.summary(health_.status, health_.message);
+  for (const auto& [key, value] : health_.key_value_pairs) {
+    stat.add(key, value);
+  }
+}
+
+
+void {{ node_class_name }}::setHealth(const unsigned char status, const std::string& msg, const std::map<std::string, std::string>& key_value_pairs) {
+  health_.status = status;
+  health_.message = msg;
+  health_.key_value_pairs = key_value_pairs;
 }
 {% endif %}
 {% if auto_shutdown %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -44,6 +44,20 @@ namespace {{ package_name }} {
 {% if has_params %}
   this->declareAndLoadParameter("param", param_, "TODO", true, false, false, 0.0, 10.0, 1.0);
 {% endif %}
+{% if has_diagnostics %}
+{% if has_subscriber %}
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.min_frequency", topic_diagnostic_config_.min_frequency, "Minimum frequency for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.max_frequency", topic_diagnostic_config_.max_frequency, "Maximum frequency for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.min_acceptable_timestamp_delta", topic_diagnostic_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.topic_diagnostic.max_acceptable_timestamp_delta", topic_diagnostic_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for incoming messages", true, true, false);
+{% endif %}
+{% if has_publisher %}
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.min_frequency", diagnosed_publisher_config_.min_frequency, "Minimum frequency for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.max_frequency", diagnosed_publisher_config_.max_frequency, "Maximum frequency for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.min_acceptable_timestamp_delta", diagnosed_publisher_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnostic_updater.diagnosed_publisher.max_acceptable_timestamp_delta", diagnosed_publisher_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for outgoing messages", true, true, false);
+{% endif %}
+{% endif %}
   this->setup();
 {% endif %}
 }

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -207,7 +207,7 @@ void {{ node_class_name }}::setup() {
   subscriber_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&subscriber_diagnostic_params_.freq_min, &subscriber_diagnostic_params_.freq_max, subscriber_diagnostic_params_.freq_tolerance, subscriber_diagnostic_params_.freq_window_size)
+    diagnostic_updater::FrequencyStatusParam(&subscriber_diagnostic_params_.min_frequency, &subscriber_diagnostic_params_.max_frequency, subscriber_diagnostic_params_.frequency_tolerance, subscriber_diagnostic_params_.frequency_window_size)
   );
 {% endif %}
 {% endif %}
@@ -346,18 +346,18 @@ void {{ node_class_name }}::timerCallback() {
 void {{ node_class_name }}::health(diagnostic_updater::DiagnosticStatusWrapper& stat) {
 
   // TODO: fill diagnostic status message appropriately based on current system state
-  if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+  if(health_ == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.");
-    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-  } else if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
+    health_ = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+  } else if(health_ == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.");
-    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  } else if(system_status_ == diagnostic_msgs::msg::DiagnosticStatus::OK) {
+    health_ = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  } else if(health_ == diagnostic_msgs::msg::DiagnosticStatus::OK) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Node is able to assess its own performance level and is reaching its desired performance level.");
-    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+    health_ = diagnostic_msgs::msg::DiagnosticStatus::STALE;
   } else {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::STALE, "Node performance level cannot be assessed");
-    system_status_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    health_ = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
   }
   // optional: add custom key-value pairs to diagnostics status
   stat.add("Dummy Status Key", "Dummy Status Value");

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -204,10 +204,10 @@ void {{ node_class_name }}::setup() {
   diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("Health", this, &{{ node_class_name }}::health);
 {% if has_subscriber %}
-  subscriber_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
+  topic_diagnostic_ = std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&subscriber_diagnostic_params_.min_frequency, &subscriber_diagnostic_params_.max_frequency, subscriber_diagnostic_params_.frequency_tolerance, subscriber_diagnostic_params_.frequency_window_size)
+    diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_min_frequency_, &topic_diagnostic_max_frequency_, topic_diagnostic_frequency_tolerance_, topic_diagnostic_frequency_window_size_)
   );
 {% endif %}
 {% endif %}
@@ -222,7 +222,7 @@ void {{ node_class_name }}::setup() {
 void {{ node_class_name }}::topicCallback(const std_msgs::msg::Int32::ConstSharedPtr& msg) {
 
 {% if has_diagnostics %}
-  subscriber_diagnostic_->tick();
+  topic_diagnostic_->tick();
 {% endif %}
   RCLCPP_INFO(this->get_logger(), "Message received: '%d'", msg->data);
 

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -204,19 +204,25 @@ void {{ node_class_name }}::setup() {
   diagnostic_updater_.setHardwareID("none");
   diagnostic_updater_.add("Health", this, &{{ node_class_name }}::health);
 {% if has_subscriber %}
+
+  // add diagnostic task for monitoring topic subscription with a moving average over min. 5 incoming messages based on expected minimum frequency
+  const int topic_diagnostic_frequency_window_size = std::ceil(5 / (diagnostic_updater_.getPeriod().seconds() * topic_diagnostic_config_.min_frequency));
   topic_diagnostic_ = std::make_unique<diagnostic_updater::TopicDiagnostic>(
     "~/input",
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_min_frequency_, &topic_diagnostic_max_frequency_, topic_diagnostic_frequency_tolerance_, topic_diagnostic_frequency_window_size_),
-    diagnostic_updater::TimeStampStatusParam(topic_diagnostic_min_acceptable_stamp_delta_, topic_diagnostic_max_acceptable_stamp_delta_)
+    diagnostic_updater::FrequencyStatusParam(&topic_diagnostic_config_.min_frequency, &topic_diagnostic_config_.max_frequency, 0.0, topic_diagnostic_frequency_window_size),
+    diagnostic_updater::TimeStampStatusParam(topic_diagnostic_config_.min_acceptable_timestamp_delta, topic_diagnostic_config_.max_acceptable_timestamp_delta)
   );
 {% endif %}
 {% if has_publisher %}
+
+  // add diagnostic task for monitoring topic publisher with a moving average over min. 5 incoming messages based on expected minimum frequency
+  const int diagnosed_publisher_frequency_window_size = std::ceil(5 / (diagnostic_updater_.getPeriod().seconds() * diagnosed_publisher_config_.min_frequency));
   diagnosed_publisher_ = std::make_unique<diagnostic_updater::DiagnosedPublisher<geometry_msgs::msg::PointStamped>>(
     publisher_,
     diagnostic_updater_,
-    diagnostic_updater::FrequencyStatusParam(&diagnosed_publisher_min_frequency_, &diagnosed_publisher_max_frequency_, diagnosed_publisher_frequency_tolerance_, diagnosed_publisher_frequency_window_size_),
-    diagnostic_updater::TimeStampStatusParam(diagnosed_publisher_min_acceptable_stamp_delta_, diagnosed_publisher_max_acceptable_stamp_delta_)
+    diagnostic_updater::FrequencyStatusParam(&diagnosed_publisher_config_.min_frequency, &diagnosed_publisher_config_.max_frequency, 0.0, diagnosed_publisher_frequency_window_size),
+    diagnostic_updater::TimeStampStatusParam(diagnosed_publisher_config_.min_acceptable_timestamp_delta, diagnosed_publisher_config_.max_acceptable_timestamp_delta)
   );
 {% endif %}
 {% endif %}
@@ -398,6 +404,16 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn {{ nod
 
 {% if has_params %}
   this->declareAndLoadParameter("param", param_, "TODO", true, false, false, 0.0, 10.0, 1.0);
+{% endif %}
+{% if has_diagnostics %}
+  this->declareAndLoadParameter("topic_diagnostic.min_frequency", topic_diagnostic_config_.min_frequency, "Minimum frequency for incoming messages", true, true, false);
+  this->declareAndLoadParameter("topic_diagnostic.max_frequency", topic_diagnostic_config_.max_frequency, "Maximum frequency for incoming messages", true, true, false);
+  this->declareAndLoadParameter("topic_diagnostic.min_acceptable_timestamp_delta", topic_diagnostic_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for incoming messages", true, true, false);
+  this->declareAndLoadParameter("topic_diagnostic.max_acceptable_timestamp_delta", topic_diagnostic_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for incoming messages", true, true, false);
+  this->declareAndLoadParameter("diagnosed_publisher.min_frequency", diagnosed_publisher_config_.min_frequency, "Minimum frequency for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnosed_publisher.max_frequency", diagnosed_publisher_config_.max_frequency, "Maximum frequency for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnosed_publisher.min_acceptable_timestamp_delta", diagnosed_publisher_config_.min_acceptable_timestamp_delta, "Minimum acceptable timestamp delta for outgoing messages", true, true, false);
+  this->declareAndLoadParameter("diagnosed_publisher.max_acceptable_timestamp_delta", diagnosed_publisher_config_.max_acceptable_timestamp_delta, "Maximum acceptable timestamp delta for outgoing messages", true, true, false);
 {% endif %}
   setup();
 

--- a/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_launch_file %}launch{% endif %}/{% if launch_file_type == 'py' %}{{ node_name }}_launch.py{% endif %}.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_launch_file %}launch{% endif %}/{% if launch_file_type == 'py' %}{{ node_name }}_launch.py{% endif %}.jinja
@@ -57,13 +57,13 @@ def generate_launch_description():
                     namespace=LaunchConfiguration("namespace"),
                     name=LaunchConfiguration("name"),
 {% if not is_component and executor_type == "MultiThreadedExecutor" %}
-{% if has_params %}
+{% if has_params or has_diagnostics %}
                     parameters=[{"num_threads": LaunchConfiguration("num_threads")}, LaunchConfiguration("params")],
 {% else %}
                     parameters=[{"num_threads": LaunchConfiguration("num_threads")}],
 {% endif %}
 {% else %}
-{% if has_params %}
+{% if has_params or has_diagnostics %}
                     parameters=[LaunchConfiguration("params")],
 {% else %}
                     parameters=[],
@@ -85,13 +85,13 @@ def generate_launch_description():
             namespace=LaunchConfiguration("namespace"),
             name=LaunchConfiguration("name"),
 {% if not is_component and executor_type == "MultiThreadedExecutor" %}
-{% if has_params %}
+{% if has_params or has_diagnostics %}
             parameters=[{"num_threads": LaunchConfiguration("num_threads")}, LaunchConfiguration("params")],
 {% else %}
             parameters=[{"num_threads": LaunchConfiguration("num_threads")}],
 {% endif %}
 {% else %}
-{% if has_params %}
+{% if has_params or has_diagnostics %}
             parameters=[LaunchConfiguration("params")],
 {% else %}
             parameters=[],

--- a/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_launch_file %}launch{% endif %}/{% if launch_file_type == 'xml' %}{{ node_name }}_launch.xml{% endif %}.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_launch_file %}launch{% endif %}/{% if launch_file_type == 'xml' %}{{ node_name }}_launch.xml{% endif %}.jinja
@@ -5,7 +5,7 @@
   <arg name="params" default="$(find-pkg-share {{ package_name }})/config/params.yml" description="path to parameter file" />
 
   <node pkg="{{ package_name }}" exec="{{ node_name }}" namespace="$(var namespace)" name="$(var name)" output="screen">
-{% if has_params %}
+{% if has_params or has_diagnostics %}
     <param from="$(var params)" />
 {% endif %}
   </node>

--- a/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
@@ -1,3 +1,6 @@
 /**/*:
   ros__parameters:
+{% if has_diagnostics %}
+    diagnostic_updater.period: 0.1
+{% endif %}
     param: 1.0

--- a/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
@@ -1,8 +1,18 @@
 /**/*:
   ros__parameters:
+    param: 1.0
 {% if has_diagnostics %}
     diagnostic_updater:
       period: 1.0
       use_fqn: false
+    topic_diagnostic:
+      min_frequency: 0.5
+      max_frequency: 1.0
+      min_acceptable_timestamp_delta: -0.1
+      max_acceptable_timestamp_delta: 0.1
+    diagnosed_publisher:
+      min_frequency: 0.5
+      max_frequency: 1.0
+      min_acceptable_timestamp_delta: -0.1
+      max_acceptable_timestamp_delta: 0.1
 {% endif %}
-    param: 1.0

--- a/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
@@ -1,6 +1,8 @@
 /**/*:
   ros__parameters:
 {% if has_diagnostics %}
-    diagnostic_updater.period: 0.1
+    diagnostic_updater:
+      period: 0.1
+      use_fqn: false
 {% endif %}
     param: 1.0

--- a/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
@@ -2,7 +2,7 @@
   ros__parameters:
 {% if has_diagnostics %}
     diagnostic_updater:
-      period: 0.1
+      period: 1.0
       use_fqn: false
 {% endif %}
     param: 1.0

--- a/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
@@ -5,14 +5,14 @@
     diagnostic_updater:
       period: 1.0
       use_fqn: false
-    topic_diagnostic:
-      min_frequency: 0.5
-      max_frequency: 1.0
-      min_acceptable_timestamp_delta: -0.1
-      max_acceptable_timestamp_delta: 0.1
-    diagnosed_publisher:
-      min_frequency: 0.5
-      max_frequency: 1.0
-      min_acceptable_timestamp_delta: -0.1
-      max_acceptable_timestamp_delta: 0.1
+      topic_diagnostic:
+        min_frequency: 0.5
+        max_frequency: 1.0
+        min_acceptable_timestamp_delta: -0.1
+        max_acceptable_timestamp_delta: 0.1
+      diagnosed_publisher:
+        min_frequency: 0.5
+        max_frequency: 1.0
+        min_acceptable_timestamp_delta: -0.1
+        max_acceptable_timestamp_delta: 0.1
 {% endif %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params or has_diagnostics %}config{% endif %}/params.yml.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/{% if has_params or has_diagnostics %}config{% endif %}/params.yml.jinja
@@ -1,6 +1,8 @@
 /**/*:
   ros__parameters:
+{% if has_params %}
     param: 1.0
+{% endif %}
 {% if has_diagnostics %}
     diagnostic_updater:
       period: 1.0

--- a/templates/ros2_python_pkg/{{ package_name }}/package.xml.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/package.xml.jinja
@@ -14,8 +14,10 @@
 {% if has_diagnostics %}
   <depend>diagnostic_updater</depend>
 {% endif %}
+{% if has_subscriber or has_publisher %}
+  <depend>geometry_msgs</depend>
+{% endif %}
   <depend>rclpy</depend>
-  <depend>std_msgs</depend>
 {% if has_service_server %}
   <depend>std_srvs</depend>
 {% endif %}

--- a/templates/ros2_python_pkg/{{ package_name }}/package.xml.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/package.xml.jinja
@@ -12,6 +12,9 @@
   <license>{{ license }}</license>
 
   <depend>rclpy</depend>
+{% if has_diagnostics %}
+  <depend>diagnostic_updater</depend>
+{% endif %}
   <depend>std_msgs</depend>
 {% if has_service_server %}
   <depend>std_srvs</depend>

--- a/templates/ros2_python_pkg/{{ package_name }}/package.xml.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/package.xml.jinja
@@ -11,10 +11,10 @@
 
   <license>{{ license }}</license>
 
-  <depend>rclpy</depend>
 {% if has_diagnostics %}
   <depend>diagnostic_updater</depend>
 {% endif %}
+  <depend>rclpy</depend>
   <depend>std_msgs</depend>
 {% if has_service_server %}
   <depend>std_srvs</depend>

--- a/templates/ros2_python_pkg/{{ package_name }}/{% if has_launch_file %}launch{% endif %}/{% if launch_file_type == 'py' %}{{ node_name }}_launch.py{% endif %}.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{% if has_launch_file %}launch{% endif %}/{% if launch_file_type == 'py' %}{{ node_name }}_launch.py{% endif %}.jinja
@@ -35,7 +35,7 @@ def generate_launch_description():
             executable="{{ node_name }}",
             namespace=LaunchConfiguration("namespace"),
             name=LaunchConfiguration("name"),
-{% if has_params %}
+{% if has_params or has_diagnostics %}
             parameters=[LaunchConfiguration("params")],
 {% else %}
             parameters=[],

--- a/templates/ros2_python_pkg/{{ package_name }}/{% if has_launch_file %}launch{% endif %}/{% if launch_file_type == 'xml' %}{{ node_name }}_launch.xml{% endif %}.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{% if has_launch_file %}launch{% endif %}/{% if launch_file_type == 'xml' %}{{ node_name }}_launch.xml{% endif %}.jinja
@@ -5,7 +5,7 @@
   <arg name="params" default="$(find-pkg-share {{ package_name }})/config/params.yml" description="path to parameter file" />
 
   <node pkg="{{ package_name }}" exec="{{ node_name }}" namespace="$(var namespace)" name="$(var name)" output="screen">
-{% if has_params %}
+{% if has_params or has_diagnostics %}
     <param from="$(arg params)" />
 {% endif %}
   </node>

--- a/templates/ros2_python_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
@@ -1,3 +1,6 @@
 /**/*:
   ros__parameters:
+{% if has_diagnostics %}
+    diagnostic_updater.period: 0.1
+{% endif %}
     param: 1.0

--- a/templates/ros2_python_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
@@ -1,6 +1,8 @@
 /**/*:
   ros__parameters:
 {% if has_diagnostics %}
-    diagnostic_updater.period: 0.1
+    diagnostic_updater:
+      period: 0.1
+      use_fqn: false
 {% endif %}
     param: 1.0

--- a/templates/ros2_python_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{% if has_params %}config{% endif %}/params.yml.jinja
@@ -1,8 +1,0 @@
-/**/*:
-  ros__parameters:
-{% if has_diagnostics %}
-    diagnostic_updater:
-      period: 0.1
-      use_fqn: false
-{% endif %}
-    param: 1.0

--- a/templates/ros2_python_pkg/{{ package_name }}/{% if has_params or has_diagnostics %}config{% endif %}/params.yml.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{% if has_params or has_diagnostics %}config{% endif %}/params.yml.jinja
@@ -1,6 +1,9 @@
 /**/*:
   ros__parameters:
+{% if has_params %}
     param: 1.0
+{% endif %}
+{% if has_diagnostics %}
     diagnostic_updater:
       period: 1.0
       use_fqn: false
@@ -14,3 +17,4 @@
         max_frequency: 1.0
         min_acceptable_timestamp_delta: -0.1
         max_acceptable_timestamp_delta: 0.1
+{% endif %}

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -3,6 +3,19 @@ import time
 {% endif %}
 from typing import Any, Optional, Union
 
+{% if has_diagnostics %}
+from diagnostic_msgs.msg import DiagnosticStatus
+from diagnostic_updater import Updater
+{% if has_subscriber %}
+from diagnostic_updater import TopicDiagnostic, FrequencyStatusParam, TimeStampStatusParam, DiagnosticStatusWrapper
+{% endif %}
+{% if has_publisher %}
+from diagnostic_updater import DiagnosedPublisher
+{% endif %}
+{% endif %}
+{% if has_subscriber or has_publisher %}
+from geometry_msgs.msg import PointStamped
+{% endif %}
 import rclpy
 {% if has_action_server %}
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
@@ -12,9 +25,6 @@ from rclpy.node import Node
 import rclpy.exceptions
 from rcl_interfaces.msg import (FloatingPointRange, IntegerRange, ParameterDescriptor, SetParametersResult)
 {% endif %}
-{% if has_subscriber or has_publisher %}
-from std_msgs.msg import Int32
-{% endif %}
 {% if has_service_server %}
 from std_srvs.srv import SetBool
 {% endif %}
@@ -22,11 +32,20 @@ from std_srvs.srv import SetBool
 from {{ package_name }}_interfaces.action import Fibonacci
 {% endif %}
 {% if has_diagnostics %}
-from diagnostic_msgs.msg import DiagnosticStatus
-from diagnostic_updater import Updater
-{% if has_subscriber %}
-from diagnostic_updater import TopicDiagnostic, FrequencyStatusParam, TimeStampStatusParam
-{% endif %}
+
+
+class TopicDiagnosticConfig:
+    def __init__(self, min_frequency: float, max_frequency: float, min_acceptable_timestamp_delta: float, max_acceptable_timestamp_delta: float):
+        self.min_frequency = min_frequency
+        self.max_frequency = max_frequency
+        self.min_acceptable_timestamp_delta = min_acceptable_timestamp_delta
+        self.max_acceptable_timestamp_delta = max_acceptable_timestamp_delta
+
+class Health:
+    def __init__(self, status: DiagnosticStatus, msg: str, key_value_pairs: Optional[dict[str, str]] = None):
+        self.status = status
+        self.msg = msg
+        self.key_value_pairs = key_value_pairs
 {% endif %}
 
 
@@ -43,9 +62,10 @@ class {{ node_class_name }}(Node):
 
         self.publisher = None
 {% endif %}
-{% if has_params %}
+{% if has_params or has_diagnostics %}
 
         self.auto_reconfigurable_params: list[str] = []
+{% if has_params %}
         self.param = self.declare_and_load_parameter(name="param",
                                                     param_type=rclpy.Parameter.Type.DOUBLE,
                                                     description="TODO",
@@ -54,9 +74,44 @@ class {{ node_class_name }}(Node):
                                                     to_value=10.0,
                                                     step_value=0.1)
 {% endif %}
+{% if has_diagnostics %}
+{% if has_subscriber %}
+        self.topic_diagnostic_config = TopicDiagnosticConfig(
+            min_frequency=self.declare_and_load_parameter(name="diagnostic_updater.topic_diagnostic.min_frequency",
+                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                          description="Minimum frequency for incoming messages"),
+            max_frequency=self.declare_and_load_parameter(name="diagnostic_updater.topic_diagnostic.max_frequency",
+                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                          description="Maximum frequency for incoming messages"),
+            min_acceptable_timestamp_delta=self.declare_and_load_parameter(name="diagnostic_updater.topic_diagnostic.min_acceptable_timestamp_delta",
+                                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                                          description="Minimum acceptable timestamp delta for incoming messages"),
+            max_acceptable_timestamp_delta=self.declare_and_load_parameter(name="diagnostic_updater.topic_diagnostic.max_acceptable_timestamp_delta",
+                                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                                          description="Maximum acceptable timestamp delta for incoming messages")
+        )
+{% endif %}
+{% if has_publisher %}
+        self.diagnosed_publisher_config = TopicDiagnosticConfig(
+            min_frequency=self.declare_and_load_parameter(name="diagnostic_updater.diagnosed_publisher.min_frequency",
+                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                          description="Minimum frequency for outgoing messages"),
+            max_frequency=self.declare_and_load_parameter(name="diagnostic_updater.diagnosed_publisher.max_frequency",
+                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                          description="Maximum frequency for outgoing messages"),
+            min_acceptable_timestamp_delta=self.declare_and_load_parameter(name="diagnostic_updater.diagnosed_publisher.min_acceptable_timestamp_delta",
+                                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                                          description="Minimum acceptable timestamp delta for outgoing messages"),
+            max_acceptable_timestamp_delta=self.declare_and_load_parameter(name="diagnostic_updater.diagnosed_publisher.max_acceptable_timestamp_delta",
+                                                                          param_type=rclpy.Parameter.Type.DOUBLE,
+                                                                          description="Maximum acceptable timestamp delta for outgoing messages")
+        )
+{% endif %}
+{% endif %}
+{% endif %}
 
         self.setup()
-{% if has_params %}
+{% if has_params or has_diagnostics %}
 
     def declare_and_load_parameter(self,
         name: str,
@@ -152,7 +207,7 @@ class {{ node_class_name }}(Node):
 
     def setup(self):
         """Sets up subscribers, publishers, etc. to configure the node"""
-{% if has_params %}
+{% if has_params or has_diagnostics %}
 
         # callback for dynamic parameter configuration
         self.add_on_set_parameters_callback(self.parameters_callback)
@@ -160,7 +215,7 @@ class {{ node_class_name }}(Node):
 {% if has_subscriber %}
 
         # subscriber for handling incoming messages
-        self.subscriber = self.create_subscription(Int32,
+        self.subscriber = self.create_subscription(PointStamped,
                                                    "~/input",
                                                    self.topic_callback,
                                                    qos_profile=10)
@@ -169,7 +224,7 @@ class {{ node_class_name }}(Node):
 {% if has_publisher %}
 
         # publisher for publishing outgoing messages
-        self.publisher = self.create_publisher(Int32,
+        self.publisher = self.create_publisher(PointStamped,
                                                "~/output",
                                                qos_profile=10)
         self.get_logger().info(f"Publishing to '{self.publisher.topic_name}'")
@@ -202,16 +257,28 @@ class {{ node_class_name }}(Node):
         # setup diagnostic updater
         self.diagnostic_updater = Updater(self)
         self.diagnostic_updater.setHardwareID(self.get_name())
-        self.diagnostic_updater.add("{{ node_name }} Status", self.diagnostics)
-        self.system_status_ = DiagnosticStatus.STALE
-        # optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
+        self.diagnostic_updater.add("Health", self.health)
+        self.health_ = Health(DiagnosticStatus.STALE, "")
 {% if has_subscriber %}
-        self.freq_bound_ = {"min": 0.5, "max": 5.0}
+        # add diagnostic task for monitoring topic subscription with a moving average over min. 5 incoming messages based on expected minimum frequency
+        from math import ceil
+        topic_diagnostic_frequency_window_size = ceil(5 / (self.diagnostic_updater.period * self.topic_diagnostic_config.min_frequency))
         self.topic_diagnostic = TopicDiagnostic(
             "~/input",
             self.diagnostic_updater,
-            FrequencyStatusParam(self.freq_bound_),
-            TimeStampStatusParam(-0.1, 0.1)
+            FrequencyStatusParam({"min": self.topic_diagnostic_config.min_frequency, "max": self.topic_diagnostic_config.max_frequency}, 0.0, topic_diagnostic_frequency_window_size),
+            TimeStampStatusParam(self.topic_diagnostic_config.min_acceptable_timestamp_delta, self.topic_diagnostic_config.max_acceptable_timestamp_delta)
+        )
+{% endif %}
+{% if has_publisher %}
+        # add diagnostic task for monitoring topic publisher with a moving average over min. 5 incoming messages based on expected minimum frequency
+        from math import ceil
+        diagnosed_publisher_frequency_window_size = ceil(5 / (self.diagnostic_updater.period * self.diagnosed_publisher_config.min_frequency))
+        self.diagnosed_publisher = DiagnosedPublisher(
+            self.publisher,
+            self.diagnostic_updater,
+            FrequencyStatusParam({"min": self.diagnosed_publisher_config.min_frequency, "max": self.diagnosed_publisher_config.max_frequency}, 0.0, diagnosed_publisher_frequency_window_size),
+            TimeStampStatusParam(self.diagnosed_publisher_config.min_acceptable_timestamp_delta, self.diagnosed_publisher_config.max_acceptable_timestamp_delta)
         )
 {% endif %}
 {% endif %}
@@ -221,14 +288,24 @@ class {{ node_class_name }}(Node):
 {% endif %}
 {% if has_subscriber %}
 
-    def topic_callback(self, msg: Int32):
+    def topic_callback(self, msg: PointStamped):
         """Processes messages received by a subscriber
 
         Args:
-            msg (Int32): message
+            msg (PointStamped): message
         """
 
-        self.get_logger().info(f"Message received: '{msg.data}'")
+{% if has_diagnostics %}
+        self.topic_diagnostic.tick(rclpy.time.Time.from_msg(msg.header.stamp))
+{% endif %}
+        self.get_logger().info(f"Message received with stamp: '{msg.header.stamp}'")
+{% endif %}
+{% if has_publisher %}
+{% if has_diagnostics %}
+        self.diagnosed_publisher.publish(msg)
+{% else %}
+        self.publisher.publish(msg)
+{% endif %}
 {% endif %}
 {% if has_service_server %}
 
@@ -348,27 +425,41 @@ class {{ node_class_name }}(Node):
 {% endif %}
 {% if has_diagnostics %}
 
-    def diagnostics(self, stat):
+    def health(self, stat: DiagnosticStatusWrapper) -> DiagnosticStatusWrapper:
         """Function called by diagnostic updater to populate diagnostics status
         """
 
-        # TODO: fill diagnostic status message appropriately based on current system state
-        if self.system_status_ == DiagnosticStatus.ERROR:
-            stat.summary(DiagnosticStatus.ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.")
-            self.system_status_ = DiagnosticStatus.WARN
-        elif self.system_status_ == DiagnosticStatus.WARN:
-            stat.summary(DiagnosticStatus.WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.")
-            self.system_status_ = DiagnosticStatus.OK
-        elif self.system_status_ == DiagnosticStatus.OK:
-            stat.summary(DiagnosticStatus.OK, "Node is able to assess its own performance level and is reaching its desired performance level.")
-            self.system_status_ = DiagnosticStatus.STALE
+        # TODO: Remove this demonstration of health status and implement real health checks using `setHealth()`
+        if self.health_.status == DiagnosticStatus.ERROR:
+            self.setHealth(DiagnosticStatus.ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.", {"uptime": f"{self.get_clock().now().nanoseconds / 1e9}"})
+            self.health_.status = DiagnosticStatus.WARN
+        elif self.health_.status == DiagnosticStatus.WARN:
+            self.setHealth(DiagnosticStatus.WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.")
+            self.health_.status = DiagnosticStatus.OK
+        elif self.health_.status == DiagnosticStatus.OK:
+            self.setHealth(DiagnosticStatus.OK, "Node is able to assess its own performance level and is reaching its desired performance level.")
+            self.health_.status = DiagnosticStatus.STALE
         else:
-            stat.summary(DiagnosticStatus.STALE, "Node performance level cannot be assessed")
-            self.system_status_ = DiagnosticStatus.ERROR
-        # optional: add custom key-value pairs to diagnostics status
-        stat.add("Dummy Status Key", "Dummy Status Value")
+            self.setHealth(DiagnosticStatus.STALE, "Node performance level cannot be assessed")
+            self.health_.status = DiagnosticStatus.ERROR
+        # end of demonstration
 
+        stat.summary(self.health_.status, self.health_.msg)
+        if self.health_.key_value_pairs is not None:
+            for key, value in self.health_.key_value_pairs.items():
+                stat.add(key, value)
         return stat
+
+    def setHealth(self, status: DiagnosticStatus, msg: str, key_value_pairs: Optional[dict[str, str]] = None):
+        """Sets the health information published by diagnostic updater
+
+        Args:
+            status (DiagnosticStatus): system status
+            msg (str): status message
+            key_value_pairs (dict[str, str], optional): additional key-value pairs
+        """
+
+        self.health_ = Health(status, msg, key_value_pairs)
 {% endif %}
 {% if auto_shutdown %}
 

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -21,6 +21,10 @@ from std_srvs.srv import SetBool
 {% if has_action_server %}
 from {{ package_name }}_interfaces.action import Fibonacci
 {% endif %}
+{% if has_diagnostics %}
+from diagnostic_msgs.msg import DiagnosticStatus
+from diagnostic_updater import Updater
+{% endif %}
 
 
 class {{ node_class_name }}(Node):
@@ -190,6 +194,14 @@ class {{ node_class_name }}(Node):
         # timer for repeatedly invoking a callback to publish messages
         self.timer = self.create_timer(1.0, self.timer_callback)
 {% endif %}
+{% if has_diagnostics %}
+
+        # setup diagnostic updater
+        self.diagnostic_updater = Updater(self)
+        self.diagnostic_updater.setHardwareID(self.get_name())
+        self.diagnostic_updater.add("{{ node_name }} Status", self.diagnostics)
+        # optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
+{% endif %}
 {% if auto_shutdown %}
 
         self.auto_shutdown_timer = self.create_timer(3.0, self.auto_shutdown_timer_callback)
@@ -320,6 +332,19 @@ class {{ node_class_name }}(Node):
         """
 
         self.get_logger().info("Timer triggered")
+{% endif %}
+{% if has_diagnostics %}
+
+    def diagnostics(self, stat):
+        """Function called by diagnostic updater to populate diagnostics status
+        """
+
+        # TODO: fill diagnostic status message appropriately based on current system state
+        stat.summary(DiagnosticStatus.OK, "Node is running properly")
+        # optional: add custom key-value pairs to diagnostics status
+        stat.add("Dummy Status Key", "Dummy Status Value")
+
+        return stat
 {% endif %}
 {% if auto_shutdown %}
 

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -423,12 +423,7 @@ class {{ node_class_name }}(Node):
         """
 
         self.get_logger().info("Timer triggered")
-{% endif %}
 {% if has_diagnostics %}
-
-    def health(self, stat: DiagnosticStatusWrapper) -> DiagnosticStatusWrapper:
-        """Function called by diagnostic updater to populate diagnostics status
-        """
 
         # TODO: Remove this demonstration of health status and implement real health checks using `setHealth()`
         if self.health_.status == DiagnosticStatus.ERROR:
@@ -444,6 +439,13 @@ class {{ node_class_name }}(Node):
             self.setHealth(DiagnosticStatus.STALE, "Node performance level cannot be assessed")
             self.health_.status = DiagnosticStatus.ERROR
         # end of demonstration
+{% endif %}
+{% endif %}
+{% if has_diagnostics %}
+
+    def health(self, stat: DiagnosticStatusWrapper) -> DiagnosticStatusWrapper:
+        """Function called by diagnostic updater to populate diagnostics status
+        """
 
         stat.summary(self.health_.status, self.health_.msg)
         if self.health_.key_value_pairs is not None:
@@ -461,6 +463,7 @@ class {{ node_class_name }}(Node):
         """
 
         self.health_ = Health(status, msg, key_value_pairs)
+        self.diagnostic_updater.force_update()
 {% endif %}
 {% if auto_shutdown %}
 

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -203,6 +203,7 @@ class {{ node_class_name }}(Node):
         self.diagnostic_updater = Updater(self)
         self.diagnostic_updater.setHardwareID(self.get_name())
         self.diagnostic_updater.add("{{ node_name }} Status", self.diagnostics)
+        self.system_status_ = DiagnosticStatus.STALE
         # optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
 {% if has_subscriber %}
         self.freq_bound_ = {"min": 0.5, "max": 5.0}
@@ -352,7 +353,18 @@ class {{ node_class_name }}(Node):
         """
 
         # TODO: fill diagnostic status message appropriately based on current system state
-        stat.summary(DiagnosticStatus.OK, "Node is running properly")
+        if self.system_status_ == DiagnosticStatus.ERROR:
+            stat.summary(DiagnosticStatus.ERROR, "Node is non-functional, unable to obtain, and/or yielding implausible data.")
+            self.system_status_ = DiagnosticStatus.WARN
+        elif self.system_status_ == DiagnosticStatus.WARN:
+            stat.summary(DiagnosticStatus.WARN, "Node is able to assess its own performance level, but is not able to reach its desired performance level.")
+            self.system_status_ = DiagnosticStatus.OK
+        elif self.system_status_ == DiagnosticStatus.OK:
+            stat.summary(DiagnosticStatus.OK, "Node is able to assess its own performance level and is reaching its desired performance level.")
+            self.system_status_ = DiagnosticStatus.STALE
+        else:
+            stat.summary(DiagnosticStatus.STALE, "Node performance level cannot be assessed")
+            self.system_status_ = DiagnosticStatus.ERROR
         # optional: add custom key-value pairs to diagnostics status
         stat.add("Dummy Status Key", "Dummy Status Value")
 

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -4,6 +4,7 @@ import time
 from typing import Any, Optional, Union
 
 {% if has_diagnostics %}
+from dataclasses import dataclass
 from diagnostic_msgs.msg import DiagnosticStatus
 from diagnostic_updater import Updater
 {% if has_subscriber %}
@@ -34,18 +35,18 @@ from {{ package_name }}_interfaces.action import Fibonacci
 {% if has_diagnostics %}
 
 
+@dataclass
 class TopicDiagnosticConfig:
-    def __init__(self, min_frequency: float, max_frequency: float, min_acceptable_timestamp_delta: float, max_acceptable_timestamp_delta: float):
-        self.min_frequency = min_frequency
-        self.max_frequency = max_frequency
-        self.min_acceptable_timestamp_delta = min_acceptable_timestamp_delta
-        self.max_acceptable_timestamp_delta = max_acceptable_timestamp_delta
+    min_frequency: float
+    max_frequency: float
+    min_acceptable_timestamp_delta: float
+    max_acceptable_timestamp_delta: float
 
+@dataclass
 class Health:
-    def __init__(self, status: DiagnosticStatus, msg: str, key_value_pairs: Optional[dict[str, str]] = None):
-        self.status = status
-        self.msg = msg
-        self.key_value_pairs = key_value_pairs
+    status: DiagnosticStatus
+    msg: str
+    key_value_pairs: Optional[dict[str, str]] = None
 {% endif %}
 
 

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -24,6 +24,9 @@ from {{ package_name }}_interfaces.action import Fibonacci
 {% if has_diagnostics %}
 from diagnostic_msgs.msg import DiagnosticStatus
 from diagnostic_updater import Updater
+{% if has_subscriber %}
+from diagnostic_updater import TopicDiagnostic, FrequencyStatusParam, TimeStampStatusParam
+{% endif %}
 {% endif %}
 
 
@@ -201,6 +204,15 @@ class {{ node_class_name }}(Node):
         self.diagnostic_updater.setHardwareID(self.get_name())
         self.diagnostic_updater.add("{{ node_name }} Status", self.diagnostics)
         # optional: add more diagnostic tasks here [https://github.com/ros/diagnostics/blob/ros2/diagnostic_updater/src/example.cpp]
+{% if has_subscriber %}
+        self.freq_bound_ = {"min": 0.5, "max": 5.0}
+        self.topic_diagnostic = TopicDiagnostic(
+            "~/input",
+            self.diagnostic_updater,
+            FrequencyStatusParam(self.freq_bound_),
+            TimeStampStatusParam(-0.1, 0.1)
+        )
+{% endif %}
 {% endif %}
 {% if auto_shutdown %}
 


### PR DESCRIPTION
A parameter `has_diagnostics` was added to questionnaire for C++ and Python ROS packages. This can be used to add a [`DiagnosticUpdater`](https://github.com/ros/diagnostics/tree/ros2/diagnostic_updater) to the ROS node which frequently publishes a diagnostic status to the `/diagnostics` topic. The publishing rate can be configured by a ROS parameter, which was set to `0.1` seconds in the template. A template `diagnostics()` function is added to the ROS node, which can be configured to set the node's diagnostic status appropriately. Further tests could be added easily, e.g. to check the input data frequency or timestamp age (see [here](https://github.com/ros/diagnostics/blob/14f4ba23d8e415b97a7195d3038b56a2a5640de2/diagnostic_updater/src/example.cpp#L172) for examples).

The param was also added to the `generate_samples.sh` script and to the tests in GitHub actions.