### PR TITLE
Add Quality-of-Service settings to subscribers and publishers

### DIFF
--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -130,7 +130,7 @@ void Ros2CppNode::setup() {
         2. sensor data: best effort, durability volatile, keep last message
                         take most recent message, no guarantee to receive every single message
         3. transient:   durability transient local, reliable, keep last message
-                        take most recent message, even if it was published while the
+                        take most recent message, even if it was published while the 
                         subscriber was offline, requires transient local publisher
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -130,7 +130,7 @@ void Ros2CppNode::setup() {
         2. sensor data: best effort, durability volatile, keep last message
                         take most recent message, no guarantee to receive every single message
         3. transient:   durability transient local, reliable, keep last message
-                        take most recent message, even if it was published while the 
+                        take most recent message, even if it was published while the
                         subscriber was offline, requires transient local publisher
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();

--- a/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_all_pkg/src/ros2_cpp_node.cpp
@@ -124,12 +124,34 @@ void Ros2CppNode::setup() {
   // callback for dynamic parameter configuration
   parameters_callback_ = this->add_on_set_parameters_callback(std::bind(&Ros2CppNode::parametersCallback, this, std::placeholders::_1));
 
-  // subscriber for handling incoming messages
-  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
+  /*  subscriber for handling incoming messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep last 10 received messages in queue
+                        default ROS 2 setting, requires reliable publisher
+        2. sensor data: best effort, durability volatile, keep last message
+                        take most recent message, no guarantee to receive every single message
+        3. transient:   durability transient local, reliable, keep last message
+                        take most recent message, even if it was published while the 
+                        subscriber was offline, requires transient local publisher
+  */
+  auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto subscriber_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", subscriber_qos_profile, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 
-  // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
+  /*  publisher for publishing outgoing messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep 10 messages in queue for sending
+                        default ROS 2 setting
+        2. sensor data: best effort, durability volatile, send last published message
+                        no re-transmission if message could not be delivered
+        3. transient:   durability transient local, reliable, send last published message
+                        keep last published message available for late-joining subscribers,
+                        requires transient local subscriber
+  */
+  auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto publisher_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", publisher_qos_profile);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 
   // service server for handling service calls

--- a/samples/ros2_cpp_component_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_component_pkg/src/ros2_cpp_node.cpp
@@ -123,7 +123,7 @@ void Ros2CppNode::setup() {
         2. sensor data: best effort, durability volatile, keep last message
                         take most recent message, no guarantee to receive every single message
         3. transient:   durability transient local, reliable, keep last message
-                        take most recent message, even if it was published while the
+                        take most recent message, even if it was published while the 
                         subscriber was offline, requires transient local publisher
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();

--- a/samples/ros2_cpp_component_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_component_pkg/src/ros2_cpp_node.cpp
@@ -123,7 +123,7 @@ void Ros2CppNode::setup() {
         2. sensor data: best effort, durability volatile, keep last message
                         take most recent message, no guarantee to receive every single message
         3. transient:   durability transient local, reliable, keep last message
-                        take most recent message, even if it was published while the 
+                        take most recent message, even if it was published while the
                         subscriber was offline, requires transient local publisher
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();

--- a/samples/ros2_cpp_component_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_component_pkg/src/ros2_cpp_node.cpp
@@ -117,12 +117,34 @@ void Ros2CppNode::setup() {
   // callback for dynamic parameter configuration
   parameters_callback_ = this->add_on_set_parameters_callback(std::bind(&Ros2CppNode::parametersCallback, this, std::placeholders::_1));
 
-  // subscriber for handling incoming messages
-  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
+  /*  subscriber for handling incoming messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep last 10 received messages in queue
+                        default ROS 2 setting, requires reliable publisher
+        2. sensor data: best effort, durability volatile, keep last message
+                        take most recent message, no guarantee to receive every single message
+        3. transient:   durability transient local, reliable, keep last message
+                        take most recent message, even if it was published while the 
+                        subscriber was offline, requires transient local publisher
+  */
+  auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto subscriber_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", subscriber_qos_profile, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 
-  // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
+  /*  publisher for publishing outgoing messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep 10 messages in queue for sending
+                        default ROS 2 setting
+        2. sensor data: best effort, durability volatile, send last published message
+                        no re-transmission if message could not be delivered
+        3. transient:   durability transient local, reliable, send last published message
+                        keep last published message available for late-joining subscribers,
+                        requires transient local subscriber
+  */
+  auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto publisher_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", publisher_qos_profile);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 }
 

--- a/samples/ros2_cpp_lifecycle_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_lifecycle_pkg/src/ros2_cpp_node.cpp
@@ -125,7 +125,7 @@ void Ros2CppNode::setup() {
         2. sensor data: best effort, durability volatile, keep last message
                         take most recent message, no guarantee to receive every single message
         3. transient:   durability transient local, reliable, keep last message
-                        take most recent message, even if it was published while the
+                        take most recent message, even if it was published while the 
                         subscriber was offline, requires transient local publisher
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();

--- a/samples/ros2_cpp_lifecycle_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_lifecycle_pkg/src/ros2_cpp_node.cpp
@@ -119,12 +119,34 @@ void Ros2CppNode::setup() {
   // callback for dynamic parameter configuration
   parameters_callback_ = this->add_on_set_parameters_callback(std::bind(&Ros2CppNode::parametersCallback, this, std::placeholders::_1));
 
-  // subscriber for handling incoming messages
-  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
+  /*  subscriber for handling incoming messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep last 10 received messages in queue
+                        default ROS 2 setting, requires reliable publisher
+        2. sensor data: best effort, durability volatile, keep last message
+                        take most recent message, no guarantee to receive every single message
+        3. transient:   durability transient local, reliable, keep last message
+                        take most recent message, even if it was published while the 
+                        subscriber was offline, requires transient local publisher
+  */
+  auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto subscriber_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", subscriber_qos_profile, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 
-  // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
+  /*  publisher for publishing outgoing messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep 10 messages in queue for sending
+                        default ROS 2 setting
+        2. sensor data: best effort, durability volatile, send last published message
+                        no re-transmission if message could not be delivered
+        3. transient:   durability transient local, reliable, send last published message
+                        keep last published message available for late-joining subscribers,
+                        requires transient local subscriber
+  */
+  auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto publisher_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", publisher_qos_profile);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 }
 

--- a/samples/ros2_cpp_lifecycle_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_lifecycle_pkg/src/ros2_cpp_node.cpp
@@ -125,7 +125,7 @@ void Ros2CppNode::setup() {
         2. sensor data: best effort, durability volatile, keep last message
                         take most recent message, no guarantee to receive every single message
         3. transient:   durability transient local, reliable, keep last message
-                        take most recent message, even if it was published while the 
+                        take most recent message, even if it was published while the
                         subscriber was offline, requires transient local publisher
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();

--- a/samples/ros2_cpp_multi_threaded_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_multi_threaded_pkg/src/ros2_cpp_node.cpp
@@ -120,12 +120,34 @@ void Ros2CppNode::setup() {
   rclcpp::SubscriptionOptions subscriber_options;
   subscriber_options.callback_group = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
-  // subscriber for handling incoming messages
-  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1), subscriber_options);
+  /*  subscriber for handling incoming messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep last 10 received messages in queue
+                        default ROS 2 setting, requires reliable publisher
+        2. sensor data: best effort, durability volatile, keep last message
+                        take most recent message, no guarantee to receive every single message
+        3. transient:   durability transient local, reliable, keep last message
+                        take most recent message, even if it was published while the 
+                        subscriber was offline, requires transient local publisher
+  */
+  auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto subscriber_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", subscriber_qos_profile, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1), subscriber_options);
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 
-  // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
+  /*  publisher for publishing outgoing messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep 10 messages in queue for sending
+                        default ROS 2 setting
+        2. sensor data: best effort, durability volatile, send last published message
+                        no re-transmission if message could not be delivered
+        3. transient:   durability transient local, reliable, send last published message
+                        keep last published message available for late-joining subscribers,
+                        requires transient local subscriber
+  */
+  auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto publisher_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", publisher_qos_profile);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 }
 

--- a/samples/ros2_cpp_multi_threaded_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_multi_threaded_pkg/src/ros2_cpp_node.cpp
@@ -126,7 +126,7 @@ void Ros2CppNode::setup() {
         2. sensor data: best effort, durability volatile, keep last message
                         take most recent message, no guarantee to receive every single message
         3. transient:   durability transient local, reliable, keep last message
-                        take most recent message, even if it was published while the
+                        take most recent message, even if it was published while the 
                         subscriber was offline, requires transient local publisher
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();

--- a/samples/ros2_cpp_multi_threaded_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_multi_threaded_pkg/src/ros2_cpp_node.cpp
@@ -126,7 +126,7 @@ void Ros2CppNode::setup() {
         2. sensor data: best effort, durability volatile, keep last message
                         take most recent message, no guarantee to receive every single message
         3. transient:   durability transient local, reliable, keep last message
-                        take most recent message, even if it was published while the 
+                        take most recent message, even if it was published while the
                         subscriber was offline, requires transient local publisher
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();

--- a/samples/ros2_cpp_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_pkg/src/ros2_cpp_node.cpp
@@ -120,7 +120,7 @@ void Ros2CppNode::setup() {
         2. sensor data: best effort, durability volatile, keep last message
                         take most recent message, no guarantee to receive every single message
         3. transient:   durability transient local, reliable, keep last message
-                        take most recent message, even if it was published while the 
+                        take most recent message, even if it was published while the
                         subscriber was offline, requires transient local publisher
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();

--- a/samples/ros2_cpp_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_pkg/src/ros2_cpp_node.cpp
@@ -120,7 +120,7 @@ void Ros2CppNode::setup() {
         2. sensor data: best effort, durability volatile, keep last message
                         take most recent message, no guarantee to receive every single message
         3. transient:   durability transient local, reliable, keep last message
-                        take most recent message, even if it was published while the
+                        take most recent message, even if it was published while the 
                         subscriber was offline, requires transient local publisher
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();

--- a/samples/ros2_cpp_pkg/src/ros2_cpp_node.cpp
+++ b/samples/ros2_cpp_pkg/src/ros2_cpp_node.cpp
@@ -114,12 +114,34 @@ void Ros2CppNode::setup() {
   // callback for dynamic parameter configuration
   parameters_callback_ = this->add_on_set_parameters_callback(std::bind(&Ros2CppNode::parametersCallback, this, std::placeholders::_1));
 
-  // subscriber for handling incoming messages
-  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
+  /*  subscriber for handling incoming messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep last 10 received messages in queue
+                        default ROS 2 setting, requires reliable publisher
+        2. sensor data: best effort, durability volatile, keep last message
+                        take most recent message, no guarantee to receive every single message
+        3. transient:   durability transient local, reliable, keep last message
+                        take most recent message, even if it was published while the 
+                        subscriber was offline, requires transient local publisher
+  */
+  auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto subscriber_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", subscriber_qos_profile, std::bind(&Ros2CppNode::topicCallback, this, std::placeholders::_1));
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 
-  // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
+  /*  publisher for publishing outgoing messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep 10 messages in queue for sending
+                        default ROS 2 setting
+        2. sensor data: best effort, durability volatile, send last published message
+                        no re-transmission if message could not be delivered
+        3. transient:   durability transient local, reliable, send last published message
+                        keep last published message available for late-joining subscribers,
+                        requires transient local subscriber
+  */
+  auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto publisher_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", publisher_qos_profile);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 }
 

--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -10,6 +10,7 @@ from geometry_msgs.msg import PointStamped
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
 import rclpy.exceptions
 from rcl_interfaces.msg import (FloatingPointRange, IntegerRange, ParameterDescriptor, SetParametersResult)
 from std_srvs.srv import SetBool
@@ -176,17 +177,37 @@ class Ros2PythonNode(Node):
         # callback for dynamic parameter configuration
         self.add_on_set_parameters_callback(self.parameters_callback)
 
-        # subscriber for handling incoming messages
+        # subscriber for handling incoming messages with suitable quality-of-service settings:
+        #   1. default:     reliable, durability volatile, keep last 10 received messages in queue
+        #                   default ROS 2 setting, requires reliable publisher
+        #   2. sensor data: best effort, durability volatile, keep last message
+        #                   take most recent message, no guarantee to receive every single message
+        #   3. transient:   durability transient local, reliable, keep last message
+        #                   take most recent message, even if it was published while the
+        #                   subscriber was offline, requires transient local publisher
+        subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
+        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
+        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
         self.subscriber = self.create_subscription(PointStamped,
                                                    "~/input",
                                                    self.topic_callback,
-                                                   qos_profile=10)
+                                                   qos_profile=subscriber_qos_profile)
         self.get_logger().info(f"Subscribed to '{self.subscriber.topic_name}'")
 
-        # publisher for publishing outgoing messages
+        # publisher for publishing outgoing messages with suitable quality-of-service settings:
+        #   1. default:     reliable, durability volatile, keep 10 messages in queue for sending
+        #                   default ROS 2 setting
+        #   2. sensor data: best effort, durability volatile, send last published message
+        #                   no re-transmission if message could not be delivered
+        #   3. transient:   durability transient local, reliable, send last published message
+        #                   keep last published message available for late-joining subscribers,
+        #                   requires transient local subscriber
+        publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
+        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
+        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
         self.publisher = self.create_publisher(PointStamped,
                                                "~/output",
-                                               qos_profile=10)
+                                               qos_profile=publisher_qos_profile)
         self.get_logger().info(f"Publishing to '{self.publisher.topic_name}'")
 
         # service server for handling service calls

--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -185,9 +185,24 @@ class Ros2PythonNode(Node):
         #   3. transient:   durability transient local, reliable, keep last message
         #                   take most recent message, even if it was published while the
         #                   subscriber was offline, requires transient local publisher
-        subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
-        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
-        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
+        subscriber_qos_profile = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.VOLATILE,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=10,
+        )
+        # subscriber_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.BEST_EFFORT,
+        #     durability=DurabilityPolicy.VOLATILE,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1,
+        # )
+        # subscriber_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.RELIABLE,
+        #     durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1,
+        # )
         self.subscriber = self.create_subscription(PointStamped,
                                                    "~/input",
                                                    self.topic_callback,

--- a/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
+++ b/samples/ros2_python_all_pkg/ros2_python_all_pkg/ros2_python_node.py
@@ -217,9 +217,24 @@ class Ros2PythonNode(Node):
         #   3. transient:   durability transient local, reliable, send last published message
         #                   keep last published message available for late-joining subscribers,
         #                   requires transient local subscriber
-        publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
-        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
-        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
+        publisher_qos_profile = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.VOLATILE,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=10
+        )
+        # publisher_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.BEST_EFFORT,
+        #     durability=DurabilityPolicy.VOLATILE,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1
+        # )
+        # publisher_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.RELIABLE,
+        #     durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1
+        # )
         self.publisher = self.create_publisher(PointStamped,
                                                "~/output",
                                                qos_profile=publisher_qos_profile)

--- a/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
+++ b/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
@@ -3,6 +3,7 @@ from typing import Any, Optional, Union
 from geometry_msgs.msg import PointStamped
 import rclpy
 from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
 import rclpy.exceptions
 from rcl_interfaces.msg import (FloatingPointRange, IntegerRange, ParameterDescriptor, SetParametersResult)
 
@@ -125,17 +126,37 @@ class Ros2PythonNode(Node):
         # callback for dynamic parameter configuration
         self.add_on_set_parameters_callback(self.parameters_callback)
 
-        # subscriber for handling incoming messages
+        # subscriber for handling incoming messages with suitable quality-of-service settings:
+        #   1. default:     reliable, durability volatile, keep last 10 received messages in queue
+        #                   default ROS 2 setting, requires reliable publisher
+        #   2. sensor data: best effort, durability volatile, keep last message
+        #                   take most recent message, no guarantee to receive every single message
+        #   3. transient:   durability transient local, reliable, keep last message
+        #                   take most recent message, even if it was published while the
+        #                   subscriber was offline, requires transient local publisher
+        subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
+        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
+        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
         self.subscriber = self.create_subscription(PointStamped,
                                                    "~/input",
                                                    self.topic_callback,
-                                                   qos_profile=10)
+                                                   qos_profile=subscriber_qos_profile)
         self.get_logger().info(f"Subscribed to '{self.subscriber.topic_name}'")
 
-        # publisher for publishing outgoing messages
+        # publisher for publishing outgoing messages with suitable quality-of-service settings:
+        #   1. default:     reliable, durability volatile, keep 10 messages in queue for sending
+        #                   default ROS 2 setting
+        #   2. sensor data: best effort, durability volatile, send last published message
+        #                   no re-transmission if message could not be delivered
+        #   3. transient:   durability transient local, reliable, send last published message
+        #                   keep last published message available for late-joining subscribers,
+        #                   requires transient local subscriber
+        publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
+        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
+        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
         self.publisher = self.create_publisher(PointStamped,
                                                "~/output",
-                                               qos_profile=10)
+                                               qos_profile=publisher_qos_profile)
         self.get_logger().info(f"Publishing to '{self.publisher.topic_name}'")
 
     def topic_callback(self, msg: PointStamped):

--- a/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
+++ b/samples/ros2_python_pkg/ros2_python_pkg/ros2_python_node.py
@@ -134,9 +134,24 @@ class Ros2PythonNode(Node):
         #   3. transient:   durability transient local, reliable, keep last message
         #                   take most recent message, even if it was published while the
         #                   subscriber was offline, requires transient local publisher
-        subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
-        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
-        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
+        subscriber_qos_profile = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.VOLATILE,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=10,
+        )
+        # subscriber_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.BEST_EFFORT,
+        #     durability=DurabilityPolicy.VOLATILE,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1,
+        # )
+        # subscriber_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.RELIABLE,
+        #     durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1,
+        # )
         self.subscriber = self.create_subscription(PointStamped,
                                                    "~/input",
                                                    self.topic_callback,
@@ -151,9 +166,24 @@ class Ros2PythonNode(Node):
         #   3. transient:   durability transient local, reliable, send last published message
         #                   keep last published message available for late-joining subscribers,
         #                   requires transient local subscriber
-        publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
-        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
-        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
+        publisher_qos_profile = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.VOLATILE,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=10
+        )
+        # publisher_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.BEST_EFFORT,
+        #     durability=DurabilityPolicy.VOLATILE,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1
+        # )
+        # publisher_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.RELIABLE,
+        #     durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1
+        # )
         self.publisher = self.create_publisher(PointStamped,
                                                "~/output",
                                                qos_profile=publisher_qos_profile)

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -177,18 +177,40 @@ void {{ node_class_name }}::setup() {
   subscriber_options.callback_group = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 {% endif %}
 
-  // subscriber for handling incoming messages
+  /*  subscriber for handling incoming messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep last 10 received messages in queue
+                        default ROS 2 setting, requires reliable publisher
+        2. sensor data: best effort, durability volatile, keep last message
+                        take most recent message, no guarantee to receive every single message
+        3. transient:   durability transient local, reliable, keep last message
+                        take most recent message, even if it was published while the 
+                        subscriber was offline, requires transient local publisher
+  */
+  auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto subscriber_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto subscriber_qos_profile = rclcpp::QoS().reliable().transient_local().keep_last(1);
 {% if executor_type == "MultiThreadedExecutor" %}
-  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&{{ node_class_name }}::topicCallback, this, std::placeholders::_1), subscriber_options);
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", subscriber_qos_profile, std::bind(&{{ node_class_name }}::topicCallback, this, std::placeholders::_1), subscriber_options);
 {% else %}
-  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", 10, std::bind(&{{ node_class_name }}::topicCallback, this, std::placeholders::_1));
+  subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", subscriber_qos_profile, std::bind(&{{ node_class_name }}::topicCallback, this, std::placeholders::_1));
 {% endif %}
   RCLCPP_INFO(this->get_logger(), "Subscribed to '%s'", subscriber_->get_topic_name());
 {% endif %}
 {% if has_publisher %}
 
-  // publisher for publishing outgoing messages
-  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", 10);
+  /*  publisher for publishing outgoing messages with suitable quality-of-service settings:
+        1. default:     reliable, durability volatile, keep 10 messages in queue for sending
+                        default ROS 2 setting
+        2. sensor data: best effort, durability volatile, send last published message
+                        no re-transmission if message could not be delivered
+        3. transient:   durability transient local, reliable, send last published message
+                        keep last published message available for late-joining subscribers,
+                        requires transient local subscriber
+  */
+  auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
+  // auto subscriber_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto subscriber_qos_profile = rclcpp::QoS().reliable().transient_local().keep_last(1);
+  publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", publisher_qos_profile);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 {% endif %}
 {% if has_service_server %}

--- a/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
+++ b/templates/ros2_cpp_pkg/{{ package_name }}/src/{{ node_name }}.cpp.jinja
@@ -188,7 +188,7 @@ void {{ node_class_name }}::setup() {
   */
   auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
   // auto subscriber_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
-  // auto subscriber_qos_profile = rclcpp::QoS().reliable().transient_local().keep_last(1);
+  // auto subscriber_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
 {% if executor_type == "MultiThreadedExecutor" %}
   subscriber_ = this->create_subscription<geometry_msgs::msg::PointStamped>("~/input", subscriber_qos_profile, std::bind(&{{ node_class_name }}::topicCallback, this, std::placeholders::_1), subscriber_options);
 {% else %}
@@ -208,8 +208,8 @@ void {{ node_class_name }}::setup() {
                         requires transient local subscriber
   */
   auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().durability_volatile();
-  // auto subscriber_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
-  // auto subscriber_qos_profile = rclcpp::QoS().reliable().transient_local().keep_last(1);
+  // auto publisher_qos_profile = rclcpp::SensorDataQoS().keep_last(1);
+  // auto publisher_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local();
   publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("~/output", publisher_qos_profile);
   RCLCPP_INFO(this->get_logger(), "Publishing to '%s'", publisher_->get_topic_name());
 {% endif %}

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -226,9 +226,24 @@ class {{ node_class_name }}(Node):
         #   3. transient:   durability transient local, reliable, keep last message
         #                   take most recent message, even if it was published while the
         #                   subscriber was offline, requires transient local publisher
-        subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
-        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
-        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
+        subscriber_qos_profile = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.VOLATILE,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=10,
+        )
+        # subscriber_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.BEST_EFFORT,
+        #     durability=DurabilityPolicy.VOLATILE,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1,
+        # )
+        # subscriber_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.RELIABLE,
+        #     durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1,
+        # )
         self.subscriber = self.create_subscription(PointStamped,
                                                    "~/input",
                                                    self.topic_callback,
@@ -245,9 +260,24 @@ class {{ node_class_name }}(Node):
         #   3. transient:   durability transient local, reliable, send last published message
         #                   keep last published message available for late-joining subscribers,
         #                   requires transient local subscriber
-        publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
-        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
-        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
+        publisher_qos_profile = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.VOLATILE,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=10
+        )
+        # publisher_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.BEST_EFFORT,
+        #     durability=DurabilityPolicy.VOLATILE,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1
+        # )
+        # publisher_qos_profile = QoSProfile(
+        #     reliability=ReliabilityPolicy.RELIABLE,
+        #     durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        #     history=HistoryPolicy.KEEP_LAST,
+        #     depth=1
+        # )
         self.publisher = self.create_publisher(PointStamped,
                                                "~/output",
                                                qos_profile=publisher_qos_profile)

--- a/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
+++ b/templates/ros2_python_pkg/{{ package_name }}/{{ package_name }}/{{ node_name }}.py.jinja
@@ -22,6 +22,9 @@ import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 {% endif %}
 from rclpy.node import Node
+{% if has_subscriber or has_publisher %}
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+{% endif %}
 {% if has_params %}
 import rclpy.exceptions
 from rcl_interfaces.msg import (FloatingPointRange, IntegerRange, ParameterDescriptor, SetParametersResult)
@@ -215,19 +218,39 @@ class {{ node_class_name }}(Node):
 {% endif %}
 {% if has_subscriber %}
 
-        # subscriber for handling incoming messages
+        # subscriber for handling incoming messages with suitable quality-of-service settings:
+        #   1. default:     reliable, durability volatile, keep last 10 received messages in queue
+        #                   default ROS 2 setting, requires reliable publisher
+        #   2. sensor data: best effort, durability volatile, keep last message
+        #                   take most recent message, no guarantee to receive every single message
+        #   3. transient:   durability transient local, reliable, keep last message
+        #                   take most recent message, even if it was published while the
+        #                   subscriber was offline, requires transient local publisher
+        subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
+        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
+        # subscriber_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
         self.subscriber = self.create_subscription(PointStamped,
                                                    "~/input",
                                                    self.topic_callback,
-                                                   qos_profile=10)
+                                                   qos_profile=subscriber_qos_profile)
         self.get_logger().info(f"Subscribed to '{self.subscriber.topic_name}'")
 {% endif %}
 {% if has_publisher %}
 
-        # publisher for publishing outgoing messages
+        # publisher for publishing outgoing messages with suitable quality-of-service settings:
+        #   1. default:     reliable, durability volatile, keep 10 messages in queue for sending
+        #                   default ROS 2 setting
+        #   2. sensor data: best effort, durability volatile, send last published message
+        #                   no re-transmission if message could not be delivered
+        #   3. transient:   durability transient local, reliable, send last published message
+        #                   keep last published message available for late-joining subscribers,
+        #                   requires transient local subscriber
+        publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=10)
+        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, durability=DurabilityPolicy.VOLATILE, history=HistoryPolicy.KEEP_LAST, depth=1)
+        # publisher_qos_profile = QoSProfile(reliability=ReliabilityPolicy.RELIABLE, durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_LAST, depth=1)
         self.publisher = self.create_publisher(PointStamped,
                                                "~/output",
-                                               qos_profile=10)
+                                               qos_profile=publisher_qos_profile)
         self.get_logger().info(f"Publishing to '{self.publisher.topic_name}'")
 {% endif %}
 {% if has_service_server %}


### PR DESCRIPTION
Add Quality-of-Service settings to the publisher and subscriber in the C++ and Python package templates.
Added three pre-defined configs with explanation.